### PR TITLE
fix isvalid_cache_header logic

### DIFF
--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -105,7 +105,7 @@ function info_cachefile(pkg::PkgId, path::String)
         io = open(path, "r")
         try
             # isvalid_cache_header returns checksum id or zero
-            isvalid_cache_header(io) > 0 || return ArgumentError("Invalid header in cache file $path.")
+            isvalid_cache_header(io) == 0 && return ArgumentError("Invalid header in cache file $path.")
             depmodnames = parse_cache_header(io)[3]
             isvalid_file_crc(io) || return ArgumentError("Invalid checksum in cache file $path.")
         finally

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -104,7 +104,8 @@ function info_cachefile(pkg::PkgId, path::String)
         local depmodnames
         io = open(path, "r")
         try
-            isvalid_cache_header(io) || return ArgumentError("Invalid header in cache file $path.")
+            # isvalid_cache_header returns checksum id or zero
+            isvalid_cache_header(io) > 0 || return ArgumentError("Invalid header in cache file $path.")
             depmodnames = parse_cache_header(io)[3]
             isvalid_file_crc(io) || return ArgumentError("Invalid checksum in cache file $path.")
         finally


### PR DESCRIPTION
Before this I was getting
```
julia> info_cachefile("Revise")
ERROR: TypeError: non-boolean (UInt64) used in boolean context
Stacktrace:
 [1] macro expansion
   @ ~/Documents/GitHub/PkgCacheInspector.jl/src/PkgCacheInspector.jl:107 [inlined]
 [2] macro expansion
   @ ./lock.jl:267 [inlined]
 [3] info_cachefile(pkg::Base.PkgId, path::String)
   @ PkgCacheInspector ~/Documents/GitHub/PkgCacheInspector.jl/src/PkgCacheInspector.jl:103
 [4] info_cachefile(pkg::Base.PkgId)
   @ PkgCacheInspector ~/Documents/GitHub/PkgCacheInspector.jl/src/PkgCacheInspector.jl:136
 [5] info_cachefile(pkgname::String)
   @ PkgCacheInspector ~/Documents/GitHub/PkgCacheInspector.jl/src/PkgCacheInspector.jl:139
 [6] top-level scope
   @ REPL[2]:1
 ```

With this
```
julia> info_cachefile("Revise")
Contents of /Users/ian/.julia/compiled/v1.10/Revise/M1Qoh_1DCqx.ji:
  modules: Any[Revise]
  init order: Any[Revise]
  115 external methods
  1701 new specializations of external methods (Base 81.5%, Base.Iterators 3.9%, Base.Broadcast 3.1%, ...)
  347 external methods with new roots
  12497 external targets
  9370 edges
  Segment sizes (bytes):
  system:      3304304 ( 55.69%)
  isbits:      2304751 ( 38.84%)
  symbols:       26597 (  0.45%)
  tags:          45520 (  0.77%)
  relocations:  252605 (  4.26%)
  gvars:             0 (  0.00%)
  fptrs:             0 (  0.00%)
```