### PR TITLE
Add support for decoding clone_targets

### DIFF
--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -148,4 +148,23 @@ end
 
 info_cachefile(pkgname::AbstractString) = info_cachefile(Base.identify_package(pkgname))
 
+function clone_targets(path::String)
+    targets = Base.parse_cache_header(path)[end]
+    io = IOBuffer(targets)
+
+    ntargets = read(io, Int32)
+    for i in 1:ntargets
+        flags = read(io, Int32)
+        nfeature = read(io, Int32)
+        feature_en = read(io, 4*nfeature)
+        feature_dis = read(io, 4*nfeature)
+        name_len = read(io, Int32)
+        name = String(read(io, name_len))
+        ext_features_len = read(io, Int32)
+        ext_features = read(io, ext_features_len)
+
+        @info "Target" name flags feature_en feature_dis ext_features
+    end
+end
+
 end


### PR DESCRIPTION
```
julia> clone_targets("/home/vchuravy/.julia/compiled/v1.10/SnoopPrecompile/TcfDT_z6cWT.ji")
┌ Info: Target
│   name = "znver2"
│   flags = 0
│   feature_en =
│    44-element Vector{UInt8}:
│     0x03
│     0x32
│     0xd8
│     0x36
│        ⋮
│     0x00
│     0x00
│     0x00
│   feature_dis =
│    44-element Vector{UInt8}:
│     0x00
│     0x00
│     0x00
│     0x40
│        ⋮
│     0x00
│     0x00
│     0x00
```
