### PR TITLE
Add utility to extract all MethodInstances

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,20 @@ version = "0.1.0"
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
+[weakdeps]
+MethodAnalysis = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
+
+[extensions]
+MethodAnalysisExt = "MethodAnalysis"
+
 [compat]
+MethodAnalysis = "0.4"
 julia = "1.9"
 
 [extras]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Colors", "Test"]
+test = ["Colors", "MethodAnalysis", "Pkg", "Test"]

--- a/ext/MethodAnalysisExt.jl
+++ b/ext/MethodAnalysisExt.jl
@@ -1,0 +1,27 @@
+module MethodAnalysisExt
+
+using PkgCacheInspector, MethodAnalysis
+
+function MethodAnalysis.methodinstances(info::PkgCacheInfo)
+    mis = Set{Core.MethodInstance}()
+    for mod in info.modules
+        for mi in methodinstances_owned_by(mod)
+            push!(mis, mi)
+        end
+    end
+    for m in info.external_methods
+        visit(m) do item
+            if item isa Core.MethodInstance
+                push!(mis, item)
+                return false
+            end
+            return true
+        end
+    end
+    for ci in info.new_specializations
+        push!(mis, ci.def)
+    end
+    return mis
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
 using PkgCacheInspector
+using MethodAnalysis
 using Test
+using Pkg
+
+Pkg.precompile()
 
 @testset "PkgCacheInspector.jl" begin
     info = info_cachefile("Colors")
@@ -7,4 +11,8 @@ using Test
     str = sprint(show, info)
     @test occursin("relocations", str) && occursin("new specializations", str) && occursin("targets", str)
     @test occursin("file size", str)
+
+    mis = methodinstances(info)
+    @test eltype(mis) === Core.MethodInstance
+    @test length(mis) > 100
 end


### PR DESCRIPTION
This is aimed at understanding whether a cache file might be missing
certain code. By collecting all MethodInstances at the time of loading
and comparing them against new inferences measured with
SnoopCompileCore when workloads are executed, we gain the ability
to check whether omission-from-cache or some other factor caused
the need for compilation.