### PR TITLE
Handle empty packages (fixes sum bug)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9'
+          - '~1.9.0-0'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -17,6 +17,7 @@ struct PkgCacheSizes
     gvarlist::Int
     fptrlist::Int
 end
+PkgCacheSizes() = PkgCacheSizes(0, 0, 0, 0, 0, 0, 0)   # for testing
 
 const cache_displaynames = [
         "system",
@@ -63,11 +64,12 @@ struct PkgCacheInfo
     filesize::Int
     cachesizes::PkgCacheSizes
 end
+PkgCacheInfo(cachefile::AbstractString, modules) = PkgCacheInfo(cachefile, modules, [], [], [], [], [], [], 0, PkgCacheSizes())
 
 function Base.show(io::IO, info::PkgCacheInfo)
     nspecs = count_module_specializations(info.new_specializations)
     nspecs = sort(collect(nspecs); by=last, rev=true)
-    nspecs_tot = sum(last, nspecs)
+    nspecs_tot = sum(last, nspecs; init=0)
 
     println(io, "Contents of ", info.cachefile, ':')
     println(io, "  modules: ", info.modules)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ using Pkg
 
 Pkg.precompile()
 
+module EmptyPkg end
+
 @testset "PkgCacheInspector.jl" begin
     info = info_cachefile("Colors")
     @test isa(info, PkgCacheInfo)
@@ -15,4 +17,10 @@ Pkg.precompile()
     mis = methodinstances(info)
     @test eltype(mis) === Core.MethodInstance
     @test length(mis) > 100
+
+    # Empty pkgimages do not cause issues
+    info = PkgCacheInfo("EmptyPkg.so", [EmptyPkg])
+    str = sprint(show, info)
+    @test occursin(r"modules: .*EmptyPkg\]", str)
+    @test occursin(r"file size: +0 \(0 bytes\)", str)
 end


### PR DESCRIPTION
In minimal packages, `sum(last, nspecs)` would fail without
a proper sentinel value.