### PR TITLE
Turn off coverage to produce pkgimage.so files

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
-          coverge: false    # coverage disables pkgimage caches
+          coverage: false    # coverage disables pkgimage caches
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,10 +33,8 @@ jobs:
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v2
         with:
-          files: lcov.info
+          coverge: false    # coverage disables pkgimage caches
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1'
+          version: 'nightly'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # PkgCacheInspector
 
 [![Build Status](https://github.com/timholy/PkgCacheInspector.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/timholy/PkgCacheInspector.jl/actions/workflows/CI.yml?query=branch%3Amain)
-[![Coverage](https://codecov.io/gh/timholy/PkgCacheInspector.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/timholy/PkgCacheInspector.jl)
 
 This package provides insight about what's stored in Julia's package precompile files.
 This works only on Julia 1.9 and above, as it targets the new pkgimg format.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using MethodAnalysis
 using Test
 using Pkg
 
+@show Base.JLOptions().code_coverage
+
 Pkg.precompile()
 
 module EmptyPkg end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using MethodAnalysis
 using Test
 using Pkg
 
-@show Base.JLOptions().code_coverage
+@show Base.JLOptions().code_coverage   # coverage must be off to write .so pkgimages
 
 Pkg.precompile()
 


### PR DESCRIPTION
Coverage modifies the generated code so substantially
that we disable usage of pkgimages. To test this package,
we can just disable coverage.