### PR TITLE
fixup call to `Base.parse_cache_header` for v1.11

### DIFF
--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -202,7 +202,11 @@ function info_cachefile(pkg::PkgId, path::String)
         try
             # isvalid_cache_header returns checksum id or zero
             isvalid_cache_header(io) == 0 && return ArgumentError("Invalid header in cache file $path.")
-            depmodnames = parse_cache_header(io)[3]
+            @static if VERSION >= v"1.11-DEV.683"
+                depmodnames = parse_cache_header(io, path)[3]
+            else
+                depmodnames = parse_cache_header(io)[3]
+            end
             isvalid_file_crc(io) || return ArgumentError("Invalid checksum in cache file $path.")
         finally
             close(io)


### PR DESCRIPTION
Starting with `Julia v1.11` we need to hand the file path to `Base.parse_cache_header` in order to get sensible debug messages. (xref https://github.com/JuliaLang/julia/pull/49866)

Q: Is it ok to bump the compat entry here or should this be done together with a version bump?