### PR TITLE
Fixup `Base.parse_cache_header` for v1.11

### DIFF
--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -202,7 +202,11 @@ function info_cachefile(pkg::PkgId, path::String)
         try
             # isvalid_cache_header returns checksum id or zero
             isvalid_cache_header(io) == 0 && return ArgumentError("Invalid header in cache file $path.")
-            depmodnames = parse_cache_header(io)[3]
+            @static if VERSION >= v"1.11-DEV.683" # https://github.com/JuliaLang/julia/pull/49866
+                depmodnames = parse_cache_header(io, path)[3]
+            else
+                depmodnames = parse_cache_header(io)[3]
+            end
             isvalid_file_crc(io) || return ArgumentError("Invalid checksum in cache file $path.")
         finally
             close(io)


### PR DESCRIPTION
`PkgCacheInspector.jl` relies on the Julia internal function `parse_cache_header`, whose signature changed in [#49866](https://github.com/JuliaLang/julia/pull/49866).

This problem was detected in https://github.com/JuliaLang/julia/issues/53570#issuecomment-2096111955.