### PR TITLE
Update ccalls in `info_cachefile` to Julia upstream changes

### DIFF
--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -182,9 +182,19 @@ end
 
 function info_cachefile(pkg::PkgId, path::String, depmods::Vector{Any}, isocache::Bool=false)
     if isocache
-        sv = ccall(:jl_restore_package_image_from_file, Any, (Cstring, Any, Cint), path, depmods, true)
+        @static if VERSION >= v"1.11.0-DEV.922" # https://github.com/JuliaLang/julia/pull/52123
+            sv = ccall(:jl_restore_package_image_from_file, Any, (Cstring, Any, Cint, Cstring, Cint), path, depmods, true, pkg.name, false)
+        elseif VERSION >= v"1.10.0-DEV.1145" # https://github.com/JuliaLang/julia/pull/49538
+            sv = ccall(:jl_restore_package_image_from_file, Any, (Cstring, Any, Cint, Cstring), path, depmods, true, pkg.name)
+        else
+            sv = ccall(:jl_restore_package_image_from_file, Any, (Cstring, Any, Cint), path, depmods, true)
+        end
     else
-        sv = ccall(:jl_restore_incremental, Any, (Cstring, Any, Cint), path, depmods, true)
+        if VERSION >= v"1.10.0-DEV.1145" # https://github.com/JuliaLang/julia/pull/49538
+            sv = ccall(:jl_restore_incremental, Any, (Cstring, Any, Cint, Cstring), path, depmods, true, pkg.name)
+        else
+            sv = ccall(:jl_restore_incremental, Any, (Cstring, Any, Cint), path, depmods, true)
+        end
     end
     if isa(sv, Exception)
         throw(sv)


### PR DESCRIPTION
The following PRs have added extra arguments to two C methods that are used by `info_cachefile`, which this PR fixes.

- https://github.com/JuliaLang/julia/pull/52123: Added the `int ignore_native` argument to jl_restore_package_image_from_file
- https://github.com/JuliaLang/julia/pull/49538: Added the `const char *pkgname` argument to jl_restore_package_image_from_file and jl_restore_incremental.