### PR TITLE
Show internal method count. Test 1.12-nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.12'
+          - '1.12-nightly'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 DocStringExtensions = "0.9"
-MethodAnalysis = "0.4"
+MethodAnalysis = "0.4, 1"
 julia = "1.12"
 
 [extensions]

--- a/ext/MethodAnalysisExt.jl
+++ b/ext/MethodAnalysisExt.jl
@@ -32,16 +32,11 @@ function PkgCacheInspector.count_internal_specializations(info::PkgCacheInfo)
 
     # Count method instances by their defining module
     for mi in all_mis
-        try
-            if isa(mi, Core.MethodInstance) && isa(mi.def, Method)
-                method_module = mi.def.module
-                if method_module in info.modules
-                    spec_counts[method_module] = get(spec_counts, method_module, 0) + 1
-                end
+        if isa(mi, Core.MethodInstance) && isa(mi.def, Method)
+            method_module = mi.def.module
+            if method_module in info.modules
+                spec_counts[method_module] = get(spec_counts, method_module, 0) + 1
             end
-        catch e
-            # Skip individual method instances that cause issues
-            continue
         end
     end
 

--- a/ext/MethodAnalysisExt.jl
+++ b/ext/MethodAnalysisExt.jl
@@ -24,4 +24,28 @@ function MethodAnalysis.methodinstances(info::PkgCacheInfo)
     return mis
 end
 
+function PkgCacheInspector.count_internal_specializations(info::PkgCacheInfo)
+    spec_counts = Dict{Module,Int}()
+
+    # Get all method instances from the cache
+    all_mis = methodinstances(info)
+
+    # Count method instances by their defining module
+    for mi in all_mis
+        try
+            if isa(mi, Core.MethodInstance) && isa(mi.def, Method)
+                method_module = mi.def.module
+                if method_module in info.modules
+                    spec_counts[method_module] = get(spec_counts, method_module, 0) + 1
+                end
+            end
+        catch e
+            # Skip individual method instances that cause issues
+            continue
+        end
+    end
+
+    return spec_counts
+end
+
 end

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -158,8 +158,10 @@ function Base.show(io::IO, info::PkgCacheInfo)
     internal_specs_sorted = Pair{Module,Int}[]
 
     internal_specs = count_internal_specializations(info)
-    internal_specs_sorted = sort(collect(internal_specs); by=last, rev=true)
-    total_internal_specs = sum(last, internal_specs_sorted; init=0)
+    if internal_specs !== nothing
+        internal_specs_sorted = sort(collect(internal_specs); by=last, rev=true)
+        total_internal_specs = sum(last, internal_specs_sorted; init=0)
+    end
 
     println(io, "Contents of ", info.cachefile, ':')
     println(io, "  modules: ", info.modules)

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -228,13 +228,9 @@ end
 # count_internal_specializations is defined in MethodAnalysisExt when MethodAnalysis is loaded
 count_internal_specializations(::Any) = nothing
 
-"""
-    count_internal_methods(info::PkgCacheInfo) → Dict{Module,Int}
-
-Count the number of methods defined within each of the package's own modules.
-These are methods that belong to the modules stored in the package image,
-as opposed to external methods which extend functions from other modules.
-"""
+# Count the number of methods defined within each of the package's own modules.
+# These are methods that belong to the modules stored in the package image,
+# as opposed to external methods which extend functions from other modules.
 function count_internal_methods(info::PkgCacheInfo)
     method_counts = Dict{Module,Int}()
     for mod in info.modules

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -148,14 +148,23 @@ function Base.show(io::IO, info::PkgCacheInfo)
     nspecs = sort(collect(nspecs); by=last, rev=true)
     nspecs_tot = sum(last, nspecs; init=0)
 
-    # Count internal methods
+    # Count internal methods and specializations
     internal_methods = count_internal_methods(info)
     total_internal = sum(values(internal_methods))
-    
+
+    # Try to count internal specializations if MethodAnalysis is available
+    internal_specs = Dict{Module,Int}()
+    total_internal_specs = 0
+    internal_specs_sorted = Pair{Module,Int}[]
+
+    internal_specs = count_internal_specializations(info)
+    internal_specs_sorted = sort(collect(internal_specs); by=last, rev=true)
+    total_internal_specs = sum(last, internal_specs_sorted; init=0)
+
     println(io, "Contents of ", info.cachefile, ':')
     println(io, "  modules: ", info.modules)
     !isempty(info.init_order) && println(io, "  init order: ", info.init_order)
-    
+
     # Show internal methods
     if total_internal > 0
         println(io, "  ", total_internal, " internal methods")
@@ -169,7 +178,20 @@ function Base.show(io::IO, info::PkgCacheInfo)
             println(io, ")")
         end
     end
-    
+
+    # Show internal specializations
+    if internal_specs === nothing
+        println(io, "  specializations of internal methods: (requires MethodAnalysis.jl)")
+    elseif total_internal_specs > 0
+        print(io, "  ", total_internal_specs, " specializations of internal methods ")
+        for i = 1:min(3, length(internal_specs_sorted))
+            mod, count = internal_specs_sorted[i]
+            pct = round(100*count/total_internal_specs; digits=1)
+            print(io, i==1 ? "(" : ", ", nameof(mod), " ", pct, "%")
+        end
+        println(io, length(internal_specs_sorted) > 3 ? ", ...)" : ")")
+    end
+
     !isempty(info.external_methods) && println(io, "  ", length(info.external_methods), " external methods")
     if !isempty(info.new_specializations)
         print(io, "  ", length(info.new_specializations), " new specializations of external methods ")
@@ -200,6 +222,9 @@ function count_module_specializations(new_specializations)
     end
     return modcount
 end
+
+# count_internal_specializations is defined in MethodAnalysisExt when MethodAnalysis is loaded
+count_internal_specializations(::Any) = nothing
 
 """
     count_internal_methods(info::PkgCacheInfo) → Dict{Module,Int}

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -233,29 +233,10 @@ count_internal_specializations(::Any) = nothing
 # as opposed to external methods which extend functions from other modules.
 function count_internal_methods(info::PkgCacheInfo)
     method_counts = Dict{Module,Int}()
-    for mod in info.modules
-        count = 0
-        # Count methods defined in this module
-        for name in names(mod; all=true)
-            if isdefined(mod, name)
-                obj = getfield(mod, name)
-                if isa(obj, Function)
-                    for method in methods(obj)
-                        if method.module == mod
-                            count += 1
-                        end
-                    end
-                elseif isa(obj, Type) && isa(obj, DataType)
-                    # Count constructors
-                    for method in methods(obj)
-                        if method.module == mod
-                            count += 1
-                        end
-                    end
-                end
-            end
+    Base.visit(Core.GlobalMethods) do method
+        if method.module in info.modules
+            method_counts[method.module] = get(method_counts, method.module, 0) + 1
         end
-        method_counts[mod] = count
     end
     return method_counts
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,8 @@ module EmptyPkg end
     str = sprint(show, info)
     @test occursin("relocations", str) && occursin("new specializations", str) && occursin("targets", str)
     @test occursin("file size", str)
+    @test occursin("internal methods", str)
+    @test occursin("specializations of internal methods", str)
 
     mis = methodinstances(info)
     @test eltype(mis) === Core.MethodInstance


### PR DESCRIPTION
Given we elaborate external methods it seems logical to do the same for internal?

```
% julia +nightly -E 'using PkgCacheInspector; info_cachefile("Pkg")'
Precompiling PkgCacheInspector finished.
  1 dependency successfully precompiled in 1 seconds. 3 already precompiled.
Contents of /Users/ian/.julia/juliaup/julia-nightly/share/julia/compiled/v1.13/Pkg/tUTdb_j73Rz.dylib:
  modules: Module[Pkg.MiniProgressBars, Pkg.GitTools, Pkg.PlatformEngines, Pkg.Versions, Pkg.Registry, Pkg.Resolve, Pkg.Types.FuzzySorting, Pkg.Types, Pkg.BinaryPlatformsCompat, Pkg.PkgArtifacts, Pkg.Operations, Pkg.API, Pkg.Apps, Pkg.REPLMode, Pkg]
  init order: Any[Pkg]
  1162 internal methods
    (API 230, Types 192, Operations 173, Resolve 131, Registry 75, REPLMode 74, Apps 53, Pkg 46, PkgArtifacts 45, Versions 30, BinaryPlatformsCompat 28, GitTools 26, PlatformEngines 26, FuzzySorting 22, MiniProgressBars 11)
  1653 external methods
  21973 new specializations of external methods (Base 73.4%, Base.Broadcast 7.2%, Core 6.9%, ...)
  987 external methods with new roots
  1159 edges
  file size:   42756560 (40.776 MiB)
  Segment sizes (bytes):
    system:      17592876 ( 52.32%)
    isbits:      13559288 ( 40.33%)
    symbols:        85317 (  0.25%)
    tags:          301624 (  0.90%)
    relocations:  1992997 (  5.93%)
    gvars:          35424 (  0.11%)
    fptrs:          56440 (  0.17%)
  Image targets:
    generic; flags=0; features_en=()
    apple-m1; flags=0; features_en=(aes, sha2, crc, lse, fullfp16, rdm, jsconv, complxnum, rcpc, ccpp, sha3, dotprod, fp16fml, dit, rcpc-immo, flagm, sb, ccdp, altnzcv, fptoint, v8_1a, v8_2a, v8_3a, v8_4a, v8_5a)
```

Written with help from Claude.