### PR TITLE
Add verbose modes. Add 1.11 support back. Various fixes. Add color

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.11'
           - '1.12'
           - '1.13-nightly'
           - 'nightly'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.12-nightly'
+          - '1.12'
+          - '1.13-nightly'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@
 *.jl.cov
 *.jl.mem
 /Manifest.toml
+/Manifest-v*.toml
+/test/Manifest.toml
 /docs/build/
 /docs/Manifest.toml
+REVIEW.md

--- a/Project.toml
+++ b/Project.toml
@@ -15,13 +15,8 @@ julia = "1.12"
 [extensions]
 MethodAnalysisExt = "MethodAnalysis"
 
-[extras]
-Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Colors", "MethodAnalysis", "Pkg", "Test"]
-
 [weakdeps]
 MethodAnalysis = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
+
+[workspace]
+projects = ["test", "docs"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 [compat]
 DocStringExtensions = "0.9"
 MethodAnalysis = "0.4, 1"
-julia = "1.12"
+julia = "1.11"
 
 [extensions]
 MethodAnalysisExt = "MethodAnalysis"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,7 @@ makedocs(;
     pages=[
         "Home" => "index.md",
     ],
+    checkdocs=:exports,
 )
 
 deploydocs(;

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,4 +20,5 @@ for understanding more about the information returned by [`info_cachefile`](@ref
 info_cachefile
 PkgCacheInfo
 PkgCacheSizes
+extending_external_methods
 ```

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -13,9 +13,9 @@ const _MODULE_COLOR   = :light_blue    # module names in groupings/summaries
 const _COUNT_COLOR    = :light_yellow  # numeric counts
 const _FUNCTION_COLOR = :light_magenta # function-name grouping rows
 
-_n(io, n) = printstyled(io, n; color=_COUNT_COLOR, bold=true)
-_mod(io, m) = printstyled(io, nameof(m); color=_MODULE_COLOR)
-_hdr(io, s) = printstyled(io, s; color=_HEADER_COLOR, bold=true)
+_count(io, n) = printstyled(io, n; color=_COUNT_COLOR, bold=true)
+_modname(io, m) = printstyled(io, nameof(m); color=_MODULE_COLOR)
+_header(io, s) = printstyled(io, s; color=_HEADER_COLOR, bold=true)
 
 # Truncate `s` to fit the caller's terminal width (minus the printed indent).
 # Falls back to `s` unchanged on Julia versions without `Base.rtruncate`.
@@ -69,7 +69,6 @@ struct PkgCacheSizes
     """
     fptrlist::Int
 end
-PkgCacheSizes() = PkgCacheSizes(0, 0, 0, 0, 0, 0, 0)   # for testing
 
 const cache_displaynames = [
         "system",
@@ -91,14 +90,14 @@ function Base.show(io::IO, szs::PkgCacheSizes)
         nd = max(nd, ndigits(nb))
         ntot += nb
     end
-    print(io, " "^indent); _hdr(io, "Segment sizes (bytes):"); println(io)
+    print(io, " "^indent); _header(io, "Segment sizes (bytes):"); println(io)
     for i = 1:nf
         nb = getfield(szs, i)
         print(io,
             " "^indent,
             "  ",
             rpad(cache_displaynames[i] * ": ", cache_displaynames_l+2))
-        _n(io, lpad(string(nb), nd))
+        _count(io, lpad(string(nb), nd))
         println(io, " (", @sprintf("% 6.2f", 100*nb/ntot), "%)")
     end
 end
@@ -182,7 +181,6 @@ struct PkgCacheInfo
     """
     verbose::Symbol
 end
-PkgCacheInfo(cachefile::AbstractString, modules) = PkgCacheInfo(cachefile, Vector{Module}(modules), [], Method[], Core.CodeInstance[], Core.CodeInstance[], [], [], 0, PkgCacheSizes(), [], Method[], :none)
 
 # Calling `jl_restore_package_image_from_file` / `jl_restore_incremental` twice on the
 # same cache file in one session corrupts internal loader state and segfaults. Cache by
@@ -324,10 +322,10 @@ function show_verbose_internal_methods(io::IO, info::PkgCacheInfo)
     total_internal = sum(length, values(methods_by_module); init=0)
     total_internal == 0 && return
 
-    print(io, "  "); _hdr(io, "Internal methods"); print(io, " ("); _n(io, total_internal); println(io, " total):")
+    print(io, "  "); _header(io, "Internal methods"); print(io, " ("); _count(io, total_internal); println(io, " total):")
     sorted_modules = sort(collect(methods_by_module); by=x->length(x[2]), rev=true)
     for (mod, mset) in sorted_modules
-        print(io, "    "); _mod(io, mod); print(io, ": "); _n(io, length(mset)); println(io, " methods")
+        print(io, "    "); _modname(io, mod); print(io, ": "); _count(io, length(mset)); println(io, " methods")
         # Group by the function the Method belongs to (using `method.name`, the symbol of
         # the function being defined — independent of which binding aliases reference it).
         by_function = Dict{Symbol, Vector{Method}}()
@@ -338,7 +336,7 @@ function show_verbose_internal_methods(io::IO, info::PkgCacheInfo)
             ms = by_function[fname]
             print(io, "      ")
             printstyled(io, fname; color=_FUNCTION_COLOR)
-            print(io, " ("); _n(io, length(ms)); println(io, " methods)")
+            print(io, " ("); _count(io, length(ms)); println(io, " methods)")
             # Render each Method via its own color-aware `show` (highlights source location).
             method_lines = sort!([sprint(show, m; context=io) for m in ms])
             for line in method_lines
@@ -356,8 +354,8 @@ Display detailed information about external methods when verbose mode is enabled
 function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
     # Show truly external methods (extension methods defined for functions in other modules)
     if !isempty(info.external_methods)
-        print(io, "  "); _hdr(io, "External methods (extending functions from other modules)")
-        print(io, " ("); _n(io, length(info.external_methods)); println(io, " total):")
+        print(io, "  "); _header(io, "External methods (extending functions from other modules)")
+        print(io, " ("); _count(io, length(info.external_methods)); println(io, " total):")
         # Group unique method definitions by the module that owns the function being extended.
         # `method.module` is the defining (worklist) module — uninformative for extension methods,
         # which by definition all live in the worklist module. Use the function-owner module instead.
@@ -374,7 +372,7 @@ function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
 
         sorted_modules = sort(collect(module_methods); by=x->length(x[2]), rev=true)
         for (mod, ms) in sorted_modules
-            print(io, "    "); _mod(io, mod); print(io, " ("); _n(io, length(ms)); println(io, " methods):")
+            print(io, "    "); _modname(io, mod); print(io, " ("); _count(io, length(ms)); println(io, " methods):")
             # Render each Method via its own color-aware `show`, propagating caller's IO context.
             method_lines = sort!([sprint(show, m; context=io) for m in ms])
             for line in method_lines
@@ -384,8 +382,8 @@ function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
     end
 
     if !isempty(info.new_specializations)
-        print(io, "  "); _hdr(io, "New specializations of external methods")
-        print(io, " ("); _n(io, length(info.new_specializations)); println(io, " total):")
+        print(io, "  "); _header(io, "New specializations of external methods")
+        print(io, " ("); _count(io, length(info.new_specializations)); println(io, " total):")
         # Group by module for better organization
         module_specs = Dict{Module, Vector{String}}()
         for spec in info.new_specializations
@@ -400,7 +398,7 @@ function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
 
         sorted_modules = sort(collect(module_specs); by=x->length(x[2]), rev=true)
         for (mod, specs) in sorted_modules
-            print(io, "    "); _mod(io, mod); print(io, " ("); _n(io, length(specs)); println(io, " specializations):")
+            print(io, "    "); _modname(io, mod); print(io, " ("); _count(io, length(specs)); println(io, " specializations):")
             sort!(specs)
             for spec in specs
                 println(io, "      ", spec)
@@ -431,7 +429,7 @@ function show_verbose_internal_method_specializations(io::IO, info::PkgCacheInfo
 
         sorted_modules = sort(collect(module_specs); by=x->length(x[2]), rev=true)
         for (mod, specs) in sorted_modules
-            print(io, "    "); _mod(io, mod); print(io, " ("); _n(io, length(specs)); println(io, " specializations):")
+            print(io, "    "); _modname(io, mod); print(io, " ("); _count(io, length(specs)); println(io, " specializations):")
             sort!(specs)
             for spec in specs
                 println(io, "      ", spec)
@@ -471,25 +469,25 @@ function Base.show(io::IO, info::PkgCacheInfo)
         total_internal_specs = total_internal_method_specs
     end
 
-    _hdr(io, "Contents of "); printstyled(io, info.cachefile; bold=true); println(io, ':')
+    _header(io, "Contents of "); printstyled(io, info.cachefile; bold=true); println(io, ':')
     print(io, "  modules: [")
     for (i, m) in enumerate(info.modules)
         i == 1 || print(io, ", ")
-        _mod(io, m)
+        _modname(io, m)
     end
     println(io, ']')
     !isempty(info.init_order) && println(io, "  init order: ", info.init_order)
 
     # Internal methods: always print a one-line summary; in verbose mode add the detail block.
     if total_internal > 0
-        print(io, "  "); _n(io, total_internal); print(io, " internal methods")
+        print(io, "  "); _count(io, total_internal); print(io, " internal methods")
         if length(internal_methods) > 1
             print(io, " (")
             sorted_internal = sort(collect(internal_methods); by=last, rev=true)
             for i = 1:length(sorted_internal)
                 mod, count = sorted_internal[i]
                 i == 1 || print(io, ", ")
-                _mod(io, mod); print(io, " "); _n(io, count)
+                _modname(io, mod); print(io, " "); _count(io, count)
             end
             print(io, ")")
         end
@@ -501,44 +499,44 @@ function Base.show(io::IO, info::PkgCacheInfo)
 
     # Internal method specializations: summary line, plus detail in verbose mode.
     if total_internal_method_specs > 0
-        print(io, "  "); _n(io, total_internal_method_specs); print(io, " specializations of internal methods ")
+        print(io, "  "); _count(io, total_internal_method_specs); print(io, " specializations of internal methods ")
         for i = 1:min(3, length(internal_method_spec_sorted))
             mod, count = internal_method_spec_sorted[i]
             pct = round(100*count/total_internal_method_specs; digits=1)
-            print(io, i==1 ? "(" : ", "); _mod(io, mod); print(io, " ", pct, "%")
+            print(io, i==1 ? "(" : ", "); _modname(io, mod); print(io, " ", pct, "%")
         end
         println(io, length(internal_method_spec_sorted) > 3 ? ", ...)" : ")")
     elseif internal_specs === nothing
         println(io, "  specializations of internal methods: (requires MethodAnalysis.jl)")
     elseif total_internal_specs > 0
-        print(io, "  "); _n(io, total_internal_specs); print(io, " specializations of internal methods ")
+        print(io, "  "); _count(io, total_internal_specs); print(io, " specializations of internal methods ")
         for i = 1:min(3, length(internal_specs_sorted))
             mod, count = internal_specs_sorted[i]
             pct = round(100*count/total_internal_specs; digits=1)
-            print(io, i==1 ? "(" : ", "); _mod(io, mod); print(io, " ", pct, "%")
+            print(io, i==1 ? "(" : ", "); _modname(io, mod); print(io, " ", pct, "%")
         end
         println(io, length(internal_specs_sorted) > 3 ? ", ...)" : ")")
     end
     if info.verbose == :internal || info.verbose == :all
         show_verbose_internal_method_specializations(io, info)
         if internal_specs !== nothing && total_internal_specs != total_internal_method_specs
-            print(io, "  "); _hdr(io, "MethodAnalysis internal specializations")
-            print(io, " ("); _n(io, total_internal_specs); println(io, " total):")
+            print(io, "  "); _header(io, "MethodAnalysis internal specializations")
+            print(io, " ("); _count(io, total_internal_specs); println(io, " total):")
             for (mod, count) in internal_specs_sorted
-                print(io, "    "); _mod(io, mod); print(io, ": "); _n(io, count); println(io, " specializations")
+                print(io, "    "); _modname(io, mod); print(io, ": "); _count(io, count); println(io, " specializations")
             end
         end
     end
 
     # External methods: summary lines, plus detail in verbose mode.
     if !isempty(info.external_methods)
-        print(io, "  "); _n(io, length(info.external_methods)); println(io, " external methods")
+        print(io, "  "); _count(io, length(info.external_methods)); println(io, " external methods")
     end
     if !isempty(info.new_specializations)
-        print(io, "  "); _n(io, length(info.new_specializations)); print(io, " new specializations of external methods ")
+        print(io, "  "); _count(io, length(info.new_specializations)); print(io, " new specializations of external methods ")
         for i = 1:min(3, length(nspecs))
             m, n = nspecs[i]
-            print(io, i==1 ? "(" : ", "); _mod(io, m); print(io, " ", round(100*n/nspecs_tot; digits=1), "%")
+            print(io, i==1 ? "(" : ", "); _modname(io, m); print(io, " ", round(100*n/nspecs_tot; digits=1), "%")
         end
         println(io, length(nspecs) > 3 ? ", ...)" : ")")
     end
@@ -547,13 +545,13 @@ function Base.show(io::IO, info::PkgCacheInfo)
     end
 
     if !isempty(info.new_method_roots)
-        print(io, "  "); _n(io, length(info.new_method_roots) ÷ 2); println(io, " methods with new roots")
+        print(io, "  "); _count(io, length(info.new_method_roots) ÷ 2); println(io, " methods with new roots")
     end
 
     print(io, "  ", rpad("file size: ", cache_displaynames_l+2))
-    _n(io, info.filesize); println(io, " (", Base.format_bytes(info.filesize), ")")
+    _count(io, info.filesize); println(io, " (", Base.format_bytes(info.filesize), ")")
     show(IOContext(io, :indent => 2), info.cachesizes)
-    print(io, "  "); _hdr(io, "Image targets:"); println(io)
+    print(io, "  "); _header(io, "Image targets:"); println(io)
     for t in info.image_targets
         println(io, "    ", t)
     end

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -17,6 +17,14 @@ _n(io, n) = printstyled(io, n; color=_COUNT_COLOR, bold=true)
 _mod(io, m) = printstyled(io, nameof(m); color=_MODULE_COLOR)
 _hdr(io, s) = printstyled(io, s; color=_HEADER_COLOR, bold=true)
 
+# Truncate `s` to fit the caller's terminal width (minus the printed indent).
+# Falls back to `s` unchanged on Julia versions without `Base.rtruncate`.
+function _truncate_for(io::IO, s::AbstractString, indent::Int)
+    isdefined(Base, :rtruncate) || return s
+    max_width = max(40, Base.displaysize(io)[2] - indent)
+    return Base.rtruncate(s, max_width)
+end
+
 using Base: PkgId, require_lock, assert_havelock, isvalid_cache_header, parse_cache_header, isvalid_file_crc,
             _tryrequire_from_serialized, find_all_in_cache_path, locate_package, stale_cachefile
 using Core: SimpleVector
@@ -128,18 +136,18 @@ struct PkgCacheInfo
         external callers. The information is therefore unavailable to PkgCacheInspector on
         those releases.
     """
-    external_methods::Vector{Any}
+    external_methods::Vector{Method}
     """
     The list of method specializations for methods defined within the package's own modules.
     These are specializations that were added during precompilation but belong to the package's own methods.
     """
-    internal_method_specializations::Vector{Any}
+    internal_method_specializations::Vector{Core.CodeInstance}
     """
     The list of novel specializations of external methods that were created during package precompilation.
     E.g., `get(::Dict{String,Float16}, ::String, ::Nothing)`: `Base` owns the method and all the types in
     this specialization, but might not have precompiled it until it was needed by a package.
     """
-    new_specializations::Vector{Any}
+    new_specializations::Vector{Core.CodeInstance}
     """
     Methods that gained new GC roots during precompilation, paired flat as
     `[method, roots, method, roots, …]`. This includes both internal and external methods.
@@ -169,13 +177,13 @@ struct PkgCacheInfo
     surface this list; in that case `count_internal_methods` falls back to walking the global
     method table.
     """
-    internal_methods::Vector{Any}
+    internal_methods::Vector{Method}
     """
     Verbose output mode for displaying method information.
     """
     verbose::Symbol
 end
-PkgCacheInfo(cachefile::AbstractString, modules) = PkgCacheInfo(cachefile, modules, [], [], [], [], [], [], 0, PkgCacheSizes(), [], [], :none)
+PkgCacheInfo(cachefile::AbstractString, modules) = PkgCacheInfo(cachefile, Vector{Module}(modules), [], Method[], Core.CodeInstance[], Core.CodeInstance[], [], [], 0, PkgCacheSizes(), [], Method[], :none)
 
 # Calling `jl_restore_package_image_from_file` / `jl_restore_incremental` twice on the
 # same cache file in one session corrupts internal loader state and segfaults. Cache by
@@ -366,17 +374,15 @@ function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
         end
 
         sorted_modules = sort(collect(module_methods); by=x->length(x[2]), rev=true)
-        for (mod, methods) in sorted_modules
-            print(io, "    "); _mod(io, mod); print(io, " ("); _n(io, length(methods)); println(io, " methods):")
+        for (mod, ms) in sorted_modules
+            print(io, "    "); _mod(io, mod); print(io, " ("); _n(io, length(ms)); println(io, " methods):")
             # Render each Method via its own color-aware `show`, propagating caller's IO context.
-            method_lines = sort!([sprint(show, m; context=io) for m in methods])
+            method_lines = sort!([sprint(show, m; context=io) for m in ms])
             for line in method_lines
                 println(io, "      ", line)
             end
         end
     end
-
-
 
     if !isempty(info.new_specializations)
         print(io, "  "); _hdr(io, "New specializations of external methods")
@@ -396,14 +402,7 @@ function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
                         end
                         # Use Julia's compact method signature display (color-aware via io ctx).
                         signature = sprint(Base.show_tuple_as_call, Symbol(""), mi.specTypes; context=io)
-                        # Truncate if rtruncate is available to avoid wrapping
-                        if isdefined(Base, :rtruncate)
-                            terminal_width = Base.displaysize(io)[2]
-                            indent_width = 8  # "      " prefix for each spec line
-                            max_width = max(40, terminal_width - indent_width)
-                            signature = Base.rtruncate(signature, max_width)
-                        end
-                        push!(module_specs[mod], signature)
+                        push!(module_specs[mod], _truncate_for(io, signature, 8))
                     end
                 end
             end
@@ -441,14 +440,7 @@ function show_verbose_internal_method_specializations(io::IO, info::PkgCacheInfo
                     end
                     # Use Julia's compact method signature display (color-aware via io ctx).
                     signature = sprint(Base.show_tuple_as_call, Symbol(""), mi.specTypes; context=io)
-                    # Truncate if rtruncate is available to avoid wrapping
-                    if isdefined(Base, :rtruncate)
-                        terminal_width = Base.displaysize(io)[2]
-                        indent_width = 8  # "      " prefix for each spec line
-                        max_width = max(40, terminal_width - indent_width)
-                        signature = Base.rtruncate(signature, max_width)
-                    end
-                    push!(module_specs[mod], signature)
+                    push!(module_specs[mod], _truncate_for(io, signature, 8))
                 end
             end
         end
@@ -588,12 +580,14 @@ function Base.show(io::IO, info::PkgCacheInfo)
 end
 
 moduleof(m::Method) = m.module
-moduleof(m::Module) = m
 
 function count_module_specializations(new_specializations)
     modcount = Dict{Module,Int}()
     for ci in new_specializations
-        m = moduleof(ci.def.def)
+        isa(ci, Core.CodeInstance) || continue
+        mi = ci.def
+        isa(mi, Core.MethodInstance) && isa(mi.def, Method) || continue
+        m = moduleof(mi.def)
         modcount[m] = get(modcount, m, 0) + 1
     end
     return modcount
@@ -690,19 +684,19 @@ function info_cachefile(pkg::PkgId, path::String, depmods::Vector{Any}, image_ta
     return info
 end
 
-function info_cachefile(pkg::PkgId, path::String, verbose::Symbol=:none)
+function info_cachefile(pkg::PkgId, path::String; verbose::Symbol=:none)
     return @lock require_lock begin
         local depmodnames, image_targets
         io = open(path, "r")
         try
             # isvalid_cache_header returns checksum id or zero
-            isvalid_cache_header(io) == 0 && return ArgumentError("Invalid header in cache file $path.")
+            isvalid_cache_header(io) == 0 && throw(ArgumentError("Invalid header in cache file $path."))
             header = parse_cache_header(io, path)
             depmodnames = header[3]
             # Position of `clone_targets` differs between Julia versions; locate it by type.
             clone_targets = header[findfirst(x -> x isa Vector{UInt8}, header)::Int]
             image_targets = Any[Base.parse_image_targets(clone_targets)...]
-            isvalid_file_crc(io) || return ArgumentError("Invalid checksum in cache file $path.")
+            isvalid_file_crc(io) || throw(ArgumentError("Invalid checksum in cache file $path."))
         finally
             close(io)
         end
@@ -726,7 +720,7 @@ function info_cachefile(pkg::PkgId, path::String, verbose::Symbol=:none)
     end
 end
 
-function info_cachefile(pkg::PkgId, verbose::Symbol=:none)
+function info_cachefile(pkg::PkgId; verbose::Symbol=:none)
     cachefiles = find_all_in_cache_path(pkg)
     isempty(cachefiles) && error(pkg, " has not yet been precompiled for julia ", Base.VERSION)
     # On Julia >= 1.13 use `PkgLoadSpec` so the cache's recorded syntax version is checked
@@ -741,7 +735,7 @@ function info_cachefile(pkg::PkgId, verbose::Symbol=:none)
         stale_cachefile(pkgspec, cf) !== true
     end
     idx === nothing && error("all cache files for ", pkg, " are stale, please precompile")
-    return info_cachefile(pkg, cachefiles[idx], verbose)
+    return info_cachefile(pkg, cachefiles[idx]; verbose)
 end
 
 """
@@ -762,11 +756,12 @@ After calling `info_cachefile("MyPkg")` you can also execute `using MyPkg` to ma
 `info_cachefile` available for use. This can allow you to load `cf`s for multiple packages into the same session
 for deeper analysis.
 
-!!! warn
+!!! warning
     Your session may be corrupted if you run `info_cachefile` for a package that had
     already been loaded into your session. Restarting with a clean session and using `info_cachefile`
     before otherwise loading the package is recommended.
 """
-info_cachefile(pkgname::AbstractString; verbose::Symbol=:none) = info_cachefile(Base.identify_package(pkgname), verbose)
+info_cachefile(pkgname::AbstractString; verbose::Symbol=:none) = info_cachefile(Base.identify_package(pkgname); verbose)
+info_cachefile(pkg::PkgId, path::AbstractString; verbose::Symbol=:none) = info_cachefile(pkg, String(path), verbose)
 
 end

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -177,6 +177,12 @@ struct PkgCacheInfo
 end
 PkgCacheInfo(cachefile::AbstractString, modules) = PkgCacheInfo(cachefile, modules, [], [], [], [], [], [], 0, PkgCacheSizes(), [], [], :none)
 
+# Calling `jl_restore_package_image_from_file` / `jl_restore_incremental` twice on the
+# same cache file in one session corrupts internal loader state and segfaults. Cache by
+# the resolved cachefile path and return the previously built `PkgCacheInfo` (with the
+# new `verbose` setting) on repeat calls.
+const _INFO_CACHE = Dict{String, PkgCacheInfo}()
+
 """
     _unpack_restored_sv(sv) -> NamedTuple
 
@@ -644,6 +650,17 @@ function count_internal_methods(info::PkgCacheInfo)
 end
 
 function info_cachefile(pkg::PkgId, path::String, depmods::Vector{Any}, image_targets::Vector{Any}, isocache::Bool=false, verbose::Symbol=:none)
+    cache_key = try realpath(path) catch; path end
+    cached = get(_INFO_CACHE, cache_key, nothing)
+    if cached !== nothing
+        @warn "`info_cachefile` already called for this cache file; returning cached result. Reloading the same pkgimage in one session would corrupt the runtime." path
+        return cached.verbose === verbose ? cached :
+            PkgCacheInfo(cached.cachefile, cached.modules, cached.init_order,
+                         cached.external_methods, cached.internal_method_specializations,
+                         cached.new_specializations, cached.new_method_roots,
+                         cached.edges, cached.filesize, cached.cachesizes,
+                         cached.image_targets, cached.internal_methods, verbose)
+    end
     if isocache
         sv = ccall(:jl_restore_package_image_from_file, Any, (Cstring, Any, Cint, Cstring, Cint), path, depmods, true, pkg.name, false)
     else
@@ -669,6 +686,7 @@ function info_cachefile(pkg::PkgId, path::String, depmods::Vector{Any}, image_ta
                         Any[], filesize(path),
                         PkgCacheSizes(parts.cachesizes_raw...),
                         image_targets, parts.internal_methods, verbose)
+    _INFO_CACHE[cache_key] = info
     return info
 end
 

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -5,6 +5,18 @@ using DocStringExtensions
 
 export info_cachefile, PkgCacheSizes, PkgCacheInfo
 
+# Color palette used throughout the rendered output. `printstyled` automatically
+# emits no ANSI codes when the destination IO lacks `:color => true`, so calls
+# below are safe under `sprint(show, info)` and in non-color terminals.
+const _HEADER_COLOR   = :cyan          # section headers, headline
+const _MODULE_COLOR   = :light_blue    # module names in groupings/summaries
+const _COUNT_COLOR    = :light_yellow  # numeric counts
+const _FUNCTION_COLOR = :light_magenta # function-name grouping rows
+
+_n(io, n) = printstyled(io, n; color=_COUNT_COLOR, bold=true)
+_mod(io, m) = printstyled(io, nameof(m); color=_MODULE_COLOR)
+_hdr(io, s) = printstyled(io, s; color=_HEADER_COLOR, bold=true)
+
 using Base: PkgId, require_lock, assert_havelock, isvalid_cache_header, parse_cache_header, isvalid_file_crc,
             _tryrequire_from_serialized, find_all_in_cache_path, locate_package, stale_cachefile
 using Core: SimpleVector
@@ -72,17 +84,15 @@ function Base.show(io::IO, szs::PkgCacheSizes)
         nd = max(nd, ndigits(nb))
         ntot += nb
     end
-    println(io, " "^indent, "Segment sizes (bytes):")
+    print(io, " "^indent); _hdr(io, "Segment sizes (bytes):"); println(io)
     for i = 1:nf
         nb = getfield(szs, i)
-        println(io,
+        print(io,
             " "^indent,
             "  ",
-            rpad(cache_displaynames[i] * ": ", cache_displaynames_l+2),
-            lpad(string(nb), nd),
-            " (",
-            @sprintf("% 6.2f", 100*nb/ntot),
-            "%)")
+            rpad(cache_displaynames[i] * ": ", cache_displaynames_l+2))
+        _n(io, lpad(string(nb), nd))
+        println(io, " (", @sprintf("% 6.2f", 100*nb/ntot), "%)")
     end
 end
 
@@ -301,10 +311,10 @@ function show_verbose_internal_methods(io::IO, info::PkgCacheInfo)
     total_internal = sum(length, values(methods_by_module); init=0)
     total_internal == 0 && return
 
-    println(io, "  Internal methods (", total_internal, " total):")
+    print(io, "  "); _hdr(io, "Internal methods"); print(io, " ("); _n(io, total_internal); println(io, " total):")
     sorted_modules = sort(collect(methods_by_module); by=x->length(x[2]), rev=true)
     for (mod, mset) in sorted_modules
-        println(io, "    ", nameof(mod), ": ", length(mset), " methods")
+        print(io, "    "); _mod(io, mod); print(io, ": "); _n(io, length(mset)); println(io, " methods")
         # Group by the function the Method belongs to (using `method.name`, the symbol of
         # the function being defined — independent of which binding aliases reference it).
         by_function = Dict{Symbol, Vector{Method}}()
@@ -313,8 +323,11 @@ function show_verbose_internal_methods(io::IO, info::PkgCacheInfo)
         end
         for fname in sort!(collect(keys(by_function)))
             ms = by_function[fname]
-            println(io, "      ", fname, " (", length(ms), " methods)")
-            method_lines = sort!([sprint(print, m) for m in ms])
+            print(io, "      ")
+            printstyled(io, fname; color=_FUNCTION_COLOR)
+            print(io, " ("); _n(io, length(ms)); println(io, " methods)")
+            # Render each Method via its own color-aware `show` (highlights source location).
+            method_lines = sort!([sprint(show, m; context=io) for m in ms])
             for line in method_lines
                 println(io, "        ", line)
             end
@@ -330,7 +343,8 @@ Display detailed information about external methods when verbose mode is enabled
 function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
     # Show truly external methods (extension methods defined for functions in other modules)
     if !isempty(info.external_methods)
-        println(io, "  External methods (extending functions from other modules) (", length(info.external_methods), " total):")
+        print(io, "  "); _hdr(io, "External methods (extending functions from other modules)")
+        print(io, " ("); _n(io, length(info.external_methods)); println(io, " total):")
         # Group unique method definitions by the module that owns the function being extended.
         # `method.module` is the defining (worklist) module — uninformative for extension methods,
         # which by definition all live in the worklist module. Use the function-owner module instead.
@@ -347,17 +361,11 @@ function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
 
         sorted_modules = sort(collect(module_methods); by=x->length(x[2]), rev=true)
         for (mod, methods) in sorted_modules
-            println(io, "    ", nameof(mod), " (", length(methods), " methods):")
-            # Capture method output in buffer and sort
-            method_buffer = IOBuffer()
-            method_io = IOContext(method_buffer, stdout)
-            for method in methods
-                println(method_io, "      ", method)
-            end
-            method_lines = split(String(take!(method_buffer)), '\n', keepempty=false)
-            sort!(method_lines)
+            print(io, "    "); _mod(io, mod); print(io, " ("); _n(io, length(methods)); println(io, " methods):")
+            # Render each Method via its own color-aware `show`, propagating caller's IO context.
+            method_lines = sort!([sprint(show, m; context=io) for m in methods])
             for line in method_lines
-                println(io, line)
+                println(io, "      ", line)
             end
         end
     end
@@ -365,7 +373,8 @@ function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
 
 
     if !isempty(info.new_specializations)
-        println(io, "  New specializations of external methods (", length(info.new_specializations), " total):")
+        print(io, "  "); _hdr(io, "New specializations of external methods")
+        print(io, " ("); _n(io, length(info.new_specializations)); println(io, " total):")
         # Group by module for better organization
         module_specs = Dict{Module, Vector{String}}()
         for spec in info.new_specializations
@@ -379,8 +388,8 @@ function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
                         if !haskey(module_specs, mod)
                             module_specs[mod] = String[]
                         end
-                        # Use Julia's compact method signature display
-                        signature = sprint(Base.show_tuple_as_call, Symbol(""), mi.specTypes)
+                        # Use Julia's compact method signature display (color-aware via io ctx).
+                        signature = sprint(Base.show_tuple_as_call, Symbol(""), mi.specTypes; context=io)
                         # Truncate if rtruncate is available to avoid wrapping
                         if isdefined(Base, :rtruncate)
                             terminal_width = Base.displaysize(io)[2]
@@ -396,8 +405,7 @@ function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
 
         sorted_modules = sort(collect(module_specs); by=x->length(x[2]), rev=true)
         for (mod, specs) in sorted_modules
-            println(io, "    ", nameof(mod), " (", length(specs), " specializations):")
-            # Sort the specializations
+            print(io, "    "); _mod(io, mod); print(io, " ("); _n(io, length(specs)); println(io, " specializations):")
             sort!(specs)
             for spec in specs
                 println(io, "      ", spec)
@@ -425,8 +433,8 @@ function show_verbose_internal_method_specializations(io::IO, info::PkgCacheInfo
                     if !haskey(module_specs, mod)
                         module_specs[mod] = String[]
                     end
-                    # Use Julia's compact method signature display
-                    signature = sprint(Base.show_tuple_as_call, Symbol(""), mi.specTypes)
+                    # Use Julia's compact method signature display (color-aware via io ctx).
+                    signature = sprint(Base.show_tuple_as_call, Symbol(""), mi.specTypes; context=io)
                     # Truncate if rtruncate is available to avoid wrapping
                     if isdefined(Base, :rtruncate)
                         terminal_width = Base.displaysize(io)[2]
@@ -441,8 +449,7 @@ function show_verbose_internal_method_specializations(io::IO, info::PkgCacheInfo
 
         sorted_modules = sort(collect(module_specs); by=x->length(x[2]), rev=true)
         for (mod, specs) in sorted_modules
-            println(io, "    ", nameof(mod), " (", length(specs), " specializations):")
-            # Sort the specializations
+            print(io, "    "); _mod(io, mod); print(io, " ("); _n(io, length(specs)); println(io, " specializations):")
             sort!(specs)
             for spec in specs
                 println(io, "      ", spec)
@@ -486,19 +493,25 @@ function Base.show(io::IO, info::PkgCacheInfo)
         total_internal_specs = total_internal_method_specs
     end
 
-    println(io, "Contents of ", info.cachefile, ':')
-    println(io, "  modules: ", info.modules)
+    _hdr(io, "Contents of "); printstyled(io, info.cachefile; bold=true); println(io, ':')
+    print(io, "  modules: [")
+    for (i, m) in enumerate(info.modules)
+        i == 1 || print(io, ", ")
+        _mod(io, m)
+    end
+    println(io, ']')
     !isempty(info.init_order) && println(io, "  init order: ", info.init_order)
 
     # Internal methods: always print a one-line summary; in verbose mode add the detail block.
     if total_internal > 0
-        print(io, "  ", total_internal, " internal methods")
+        print(io, "  "); _n(io, total_internal); print(io, " internal methods")
         if length(internal_methods) > 1
             print(io, " (")
             sorted_internal = sort(collect(internal_methods); by=last, rev=true)
             for i = 1:length(sorted_internal)
                 mod, count = sorted_internal[i]
-                print(io, i==1 ? "" : ", ", nameof(mod), " ", count)
+                i == 1 || print(io, ", ")
+                _mod(io, mod); print(io, " "); _n(io, count)
             end
             print(io, ")")
         end
@@ -510,41 +523,44 @@ function Base.show(io::IO, info::PkgCacheInfo)
 
     # Internal method specializations: summary line, plus detail in verbose mode.
     if total_internal_method_specs > 0
-        print(io, "  ", total_internal_method_specs, " specializations of internal methods ")
+        print(io, "  "); _n(io, total_internal_method_specs); print(io, " specializations of internal methods ")
         for i = 1:min(3, length(internal_method_spec_sorted))
             mod, count = internal_method_spec_sorted[i]
             pct = round(100*count/total_internal_method_specs; digits=1)
-            print(io, i==1 ? "(" : ", ", nameof(mod), " ", pct, "%")
+            print(io, i==1 ? "(" : ", "); _mod(io, mod); print(io, " ", pct, "%")
         end
         println(io, length(internal_method_spec_sorted) > 3 ? ", ...)" : ")")
     elseif internal_specs === nothing
         println(io, "  specializations of internal methods: (requires MethodAnalysis.jl)")
     elseif total_internal_specs > 0
-        print(io, "  ", total_internal_specs, " specializations of internal methods ")
+        print(io, "  "); _n(io, total_internal_specs); print(io, " specializations of internal methods ")
         for i = 1:min(3, length(internal_specs_sorted))
             mod, count = internal_specs_sorted[i]
             pct = round(100*count/total_internal_specs; digits=1)
-            print(io, i==1 ? "(" : ", ", nameof(mod), " ", pct, "%")
+            print(io, i==1 ? "(" : ", "); _mod(io, mod); print(io, " ", pct, "%")
         end
         println(io, length(internal_specs_sorted) > 3 ? ", ...)" : ")")
     end
     if info.verbose == :internal || info.verbose == :all
         show_verbose_internal_method_specializations(io, info)
         if internal_specs !== nothing && total_internal_specs != total_internal_method_specs
-            println(io, "  MethodAnalysis internal specializations (", total_internal_specs, " total):")
+            print(io, "  "); _hdr(io, "MethodAnalysis internal specializations")
+            print(io, " ("); _n(io, total_internal_specs); println(io, " total):")
             for (mod, count) in internal_specs_sorted
-                println(io, "    ", nameof(mod), ": ", count, " specializations")
+                print(io, "    "); _mod(io, mod); print(io, ": "); _n(io, count); println(io, " specializations")
             end
         end
     end
 
     # External methods: summary lines, plus detail in verbose mode.
-    !isempty(info.external_methods) && println(io, "  ", length(info.external_methods), " external methods")
+    if !isempty(info.external_methods)
+        print(io, "  "); _n(io, length(info.external_methods)); println(io, " external methods")
+    end
     if !isempty(info.new_specializations)
-        print(io, "  ", length(info.new_specializations), " new specializations of external methods ")
+        print(io, "  "); _n(io, length(info.new_specializations)); print(io, " new specializations of external methods ")
         for i = 1:min(3, length(nspecs))
             m, n = nspecs[i]
-            print(io, i==1 ? "(" : ", ", m, " ", round(100*n/nspecs_tot; digits=1), "%")
+            print(io, i==1 ? "(" : ", "); _mod(io, m); print(io, " ", round(100*n/nspecs_tot; digits=1), "%")
         end
         println(io, length(nspecs) > 3 ? ", ...)" : ")")
     end
@@ -552,11 +568,14 @@ function Base.show(io::IO, info::PkgCacheInfo)
         show_verbose_external_methods(io, info)
     end
 
-    !isempty(info.new_method_roots) && println(io, "  ", length(info.new_method_roots) ÷ 2, " methods with new roots")
+    if !isempty(info.new_method_roots)
+        print(io, "  "); _n(io, length(info.new_method_roots) ÷ 2); println(io, " methods with new roots")
+    end
 
-    println(io, "  ", rpad("file size: ", cache_displaynames_l+2), info.filesize, " (", Base.format_bytes(info.filesize),")")
+    print(io, "  ", rpad("file size: ", cache_displaynames_l+2))
+    _n(io, info.filesize); println(io, " (", Base.format_bytes(info.filesize), ")")
     show(IOContext(io, :indent => 2), info.cachesizes)
-    println(io, "  Image targets: ")
+    print(io, "  "); _hdr(io, "Image targets:"); println(io)
     for t in info.image_targets
         println(io, "    ", t)
     end

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -271,63 +271,52 @@ end
 Display detailed information about internal methods when verbose mode is enabled.
 """
 function show_verbose_internal_methods(io::IO, info::PkgCacheInfo)
-    internal_methods = count_internal_methods(info)
-    total_internal = sum(values(internal_methods))
-
-    if total_internal > 0
-        println(io, "  Internal methods (", total_internal, " total):")
-        sorted_internal = sort(collect(internal_methods); by=last, rev=true)
-        for (mod, count) in sorted_internal
-            println(io, "    ", nameof(mod), ": ", count, " methods")
-            # Show individual methods for each module
+    # Collect a *deduplicated* set of internal `Method`s. Prefer the exact list from
+    # `info.internal_methods` (populated on Julia ≥ 1.13); fall back to walking each
+    # module's bindings on older Julias. Walking via `names(mod; all=true)` and listing
+    # `methods(getfield(mod, name))` per binding produces duplicates whenever multiple
+    # gensym'd bindings (e.g. `var"#12#val"`) alias the same function — collecting into a
+    # `Set{Method}` removes that double-counting.
+    methods_by_module = Dict{Module, Set{Method}}()
+    if !isempty(info.internal_methods)
+        for m in info.internal_methods
+            isa(m, Method) || continue
+            push!(get!(Set{Method}, methods_by_module, m.module), m)
+        end
+    else
+        for mod in info.modules
             for name in names(mod; all=true)
-                if isdefined(mod, name)
-                    obj = getfield(mod, name)
-                    if isa(obj, Function)
-                        method_list = Method[]
-                        for method in methods(obj)
-                            if method.module == mod
-                                push!(method_list, method)
-                            end
-                        end
-                        if !isempty(method_list)
-                            println(io, "      ", name, " (", length(method_list), " methods)")
-                            # Capture method output in buffer and sort
-                            method_buffer = IOBuffer()
-                            method_io = IOContext(method_buffer, stdout)
-                            for method in method_list
-                                println(method_io, "        ", method)
-                            end
-                            method_lines = split(String(take!(method_buffer)), '\n', keepempty=false)
-                            sort!(method_lines)
-                            for line in method_lines
-                                println(io, line)
-                            end
-                        end
-                    elseif isa(obj, Type) && isa(obj, DataType)
-                        # Show constructors
-                        method_list = Method[]
-                        for method in methods(obj)
-                            if method.module == mod
-                                push!(method_list, method)
-                            end
-                        end
-                        if !isempty(method_list)
-                            println(io, "      ", name, " (", length(method_list), " constructors)")
-                            # Capture constructor output in buffer and sort
-                            constructor_buffer = IOBuffer()
-                            constructor_io = IOContext(constructor_buffer, stdout)
-                            for method in method_list
-                                println(constructor_io, "        ", method)
-                            end
-                            constructor_lines = split(String(take!(constructor_buffer)), '\n', keepempty=false)
-                            sort!(constructor_lines)
-                            for line in constructor_lines
-                                println(io, line)
-                            end
-                        end
+                isdefined(mod, name) || continue
+                obj = getfield(mod, name)
+                if isa(obj, Function) || (isa(obj, Type) && isa(obj, DataType))
+                    for method in methods(obj)
+                        method.module == mod || continue
+                        push!(get!(Set{Method}, methods_by_module, mod), method)
                     end
                 end
+            end
+        end
+    end
+
+    total_internal = sum(length, values(methods_by_module); init=0)
+    total_internal == 0 && return
+
+    println(io, "  Internal methods (", total_internal, " total):")
+    sorted_modules = sort(collect(methods_by_module); by=x->length(x[2]), rev=true)
+    for (mod, mset) in sorted_modules
+        println(io, "    ", nameof(mod), ": ", length(mset), " methods")
+        # Group by the function the Method belongs to (using `method.name`, the symbol of
+        # the function being defined — independent of which binding aliases reference it).
+        by_function = Dict{Symbol, Vector{Method}}()
+        for m in mset
+            push!(get!(Vector{Method}, by_function, m.name), m)
+        end
+        for fname in sort!(collect(keys(by_function)))
+            ms = by_function[fname]
+            println(io, "      ", fname, " (", length(ms), " methods)")
+            method_lines = sort!([sprint(print, m) for m in ms])
+            for line in method_lines
+                println(io, "        ", line)
             end
         end
     end

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -109,8 +109,14 @@ struct PkgCacheInfo
     init_order::Vector{Any}
     """
     The list of methods added to external modules. E.g., `Base.push!(v::MyNewVector, x)`.
+    These are methods that extend functions owned by other modules.
     """
     external_methods::Vector{Any}
+    """
+    The list of method specializations for methods defined within the package's own modules.
+    These are specializations that were added during precompilation but belong to the package's own methods.
+    """
+    internal_method_specializations::Vector{Any}
     """
     The list of novel specializations of external methods that were created during package precompilation.
     E.g., `get(::Dict{String,Float16}, ::String, ::Nothing)`: `Base` owns the method and all the types in
@@ -123,9 +129,8 @@ struct PkgCacheInfo
     """
     new_method_roots::Vector{Any}
     """
-    A lookup table of `external_targets` dependencies: `[mi1, indxs1, mi2, indxs2...]` means that `mi1`
-    (cached in this pkgimage) depends on `external_targets[idxs1]`; `mi2` depends on `external_targets[idxs2]`,
-    and so on.
+    Reserved for backward compatibility; currently always empty. The previous semantics (an
+    `external_targets` lookup table) no longer reflect what `jl_restore_incremental` returns.
     """
     edges::Vector{Any}
     """
@@ -140,8 +145,276 @@ struct PkgCacheInfo
     The image targets that were cloned into the pkgimage, if used.
     """
     image_targets::Vector{Any}
+    """
+    Verbose output mode for displaying method information.
+    """
+    verbose::Symbol
 end
-PkgCacheInfo(cachefile::AbstractString, modules) = PkgCacheInfo(cachefile, modules, [], [], [], [], [], 0, PkgCacheSizes(), [])
+PkgCacheInfo(cachefile::AbstractString, modules) = PkgCacheInfo(cachefile, modules, [], [], [], [], [], [], 0, PkgCacheSizes(), [], :none)
+
+"""
+    _unpack_restored_sv(sv) -> NamedTuple
+
+Unpack the SimpleVector returned by `jl_restore_incremental`/`jl_restore_package_image_from_file`
+(with `completeinfo=true`), normalizing across Julia versions.
+
+Julia 1.12 returns a 7-element svec: `(restored, init_order, edges, ext_edges, extext_methods,
+method_roots_list, cachesizes_sv)`.
+
+Julia 1.13+ (and master) returns a 5-element svec: `(restored, init_order, internal_methods,
+method_roots_list, cachesizes_sv)` where `internal_methods` is a flat heterogeneous list mixing
+`Core.TypeMapEntry` (the old `extext_methods`), `Method` (new internal methods), and
+`Core.CodeInstance` (the old `edges` and `ext_edges` merged).
+"""
+function _unpack_restored_sv(sv)
+    n = length(sv)
+    modules = sv[1]
+    init_order = sv[2]
+    code_instances = Core.CodeInstance[]
+    extext_entries = Core.TypeMapEntry[]
+    if n == 7
+        # Julia 1.12 layout
+        for x in sv[3]; isa(x, Core.CodeInstance) && push!(code_instances, x); end
+        for x in sv[4]; isa(x, Core.CodeInstance) && push!(code_instances, x); end
+        for x in sv[5]; isa(x, Core.TypeMapEntry) && push!(extext_entries, x); end
+        method_roots_list = sv[6]
+        cachesizes_raw = sv[7]
+    elseif n == 5
+        # Julia 1.13+/master layout
+        for x in sv[3]
+            if isa(x, Core.CodeInstance)
+                push!(code_instances, x)
+            elseif isa(x, Core.TypeMapEntry)
+                push!(extext_entries, x)
+            end
+            # Methods present in this list are also discoverable via `Core.methodtable`,
+            # so they are accounted for by `count_internal_methods`.
+        end
+        method_roots_list = sv[4]
+        cachesizes_raw = sv[5]
+    else
+        error("Unexpected SimpleVector layout (length $n) returned by Julia $(VERSION); ",
+              "PkgCacheInspector needs updating.")
+    end
+    return (; modules, init_order, code_instances, extext_entries,
+              method_roots_list, cachesizes_raw)
+end
+
+"""
+    _split_code_instances(code_instances, modules) -> (internal, external)
+
+Partition `code_instances` into those whose underlying method belongs to one of `modules`
+(internal specializations) and those that don't (new specializations of external methods).
+"""
+function _split_code_instances(code_instances, modules)
+    internal = Core.CodeInstance[]
+    external = Core.CodeInstance[]
+    for ci in code_instances
+        mi = ci.def
+        m = isa(mi, Core.MethodInstance) && isa(mi.def, Method) ? mi.def : nothing
+        if m !== nothing && m.module in modules
+            push!(internal, ci)
+        else
+            push!(external, ci)
+        end
+    end
+    return internal, external
+end
+
+"""
+    show_verbose_internal_methods(io::IO, info::PkgCacheInfo)
+
+Display detailed information about internal methods when verbose mode is enabled.
+"""
+function show_verbose_internal_methods(io::IO, info::PkgCacheInfo)
+    internal_methods = count_internal_methods(info)
+    total_internal = sum(values(internal_methods))
+
+    if total_internal > 0
+        println(io, "  Internal methods (", total_internal, " total):")
+        sorted_internal = sort(collect(internal_methods); by=last, rev=true)
+        for (mod, count) in sorted_internal
+            println(io, "    ", nameof(mod), ": ", count, " methods")
+            # Show individual methods for each module
+            for name in names(mod; all=true)
+                if isdefined(mod, name)
+                    obj = getfield(mod, name)
+                    if isa(obj, Function)
+                        method_list = Method[]
+                        for method in methods(obj)
+                            if method.module == mod
+                                push!(method_list, method)
+                            end
+                        end
+                        if !isempty(method_list)
+                            println(io, "      ", name, " (", length(method_list), " methods)")
+                            # Capture method output in buffer and sort
+                            method_buffer = IOBuffer()
+                            method_io = IOContext(method_buffer, stdout)
+                            for method in method_list
+                                println(method_io, "        ", method)
+                            end
+                            method_lines = split(String(take!(method_buffer)), '\n', keepempty=false)
+                            sort!(method_lines)
+                            for line in method_lines
+                                println(io, line)
+                            end
+                        end
+                    elseif isa(obj, Type) && isa(obj, DataType)
+                        # Show constructors
+                        method_list = Method[]
+                        for method in methods(obj)
+                            if method.module == mod
+                                push!(method_list, method)
+                            end
+                        end
+                        if !isempty(method_list)
+                            println(io, "      ", name, " (", length(method_list), " constructors)")
+                            # Capture constructor output in buffer and sort
+                            constructor_buffer = IOBuffer()
+                            constructor_io = IOContext(constructor_buffer, stdout)
+                            for method in method_list
+                                println(constructor_io, "        ", method)
+                            end
+                            constructor_lines = split(String(take!(constructor_buffer)), '\n', keepempty=false)
+                            sort!(constructor_lines)
+                            for line in constructor_lines
+                                println(io, line)
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+"""
+    show_verbose_external_methods(io::IO, info::PkgCacheInfo)
+
+Display detailed information about external methods when verbose mode is enabled.
+"""
+function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
+    # Show truly external methods (extension methods defined for functions in other modules)
+    if !isempty(info.external_methods)
+        println(io, "  External methods (extending functions from other modules) (", length(info.external_methods), " total):")
+        # Group unique method definitions by the module that owns the function being extended
+        external_method_defs = Set{Method}(m for m in info.external_methods if isa(m, Method))
+
+        module_methods = Dict{Module, Vector{Method}}()
+        for method in external_method_defs
+            mod = method.module
+            if !haskey(module_methods, mod)
+                module_methods[mod] = Method[]
+            end
+            push!(module_methods[mod], method)
+        end
+
+        sorted_modules = sort(collect(module_methods); by=x->length(x[2]), rev=true)
+        for (mod, methods) in sorted_modules
+            println(io, "    ", nameof(mod), " (", length(methods), " methods):")
+            # Capture method output in buffer and sort
+            method_buffer = IOBuffer()
+            method_io = IOContext(method_buffer, stdout)
+            for method in methods
+                println(method_io, "      ", method)
+            end
+            method_lines = split(String(take!(method_buffer)), '\n', keepempty=false)
+            sort!(method_lines)
+            for line in method_lines
+                println(io, line)
+            end
+        end
+    end
+
+
+
+    if !isempty(info.new_specializations)
+        println(io, "  New specializations of external methods (", length(info.new_specializations), " total):")
+        # Group by module for better organization
+        module_specs = Dict{Module, Vector{String}}()
+        for spec in info.new_specializations
+            if isa(spec, Core.CodeInstance) && isa(spec.def, Core.MethodInstance)
+                mi = spec.def
+                if isa(mi.def, Method)
+                    method = mi.def
+                    mod = method.module
+                    # Only include truly external methods here
+                    if mod ∉ info.modules
+                        if !haskey(module_specs, mod)
+                            module_specs[mod] = String[]
+                        end
+                        # Use Julia's compact method signature display
+                        signature = sprint(Base.show_tuple_as_call, Symbol(""), mi.specTypes)
+                        # Truncate if rtruncate is available to avoid wrapping
+                        if isdefined(Base, :rtruncate)
+                            terminal_width = Base.displaysize(io)[2]
+                            indent_width = 8  # "      " prefix for each spec line
+                            max_width = max(40, terminal_width - indent_width)
+                            signature = Base.rtruncate(signature, max_width)
+                        end
+                        push!(module_specs[mod], signature)
+                    end
+                end
+            end
+        end
+
+        sorted_modules = sort(collect(module_specs); by=x->length(x[2]), rev=true)
+        for (mod, specs) in sorted_modules
+            println(io, "    ", nameof(mod), " (", length(specs), " specializations):")
+            # Sort the specializations
+            sort!(specs)
+            for spec in specs
+                println(io, "      ", spec)
+            end
+        end
+    end
+end
+
+"""
+    show_verbose_internal_method_specializations(io::IO, info::PkgCacheInfo)
+
+Display detailed information about internal method specializations when verbose mode is enabled.
+"""
+function show_verbose_internal_method_specializations(io::IO, info::PkgCacheInfo)
+    if !isempty(info.internal_method_specializations)
+        println(io, "  Internal method specializations (", length(info.internal_method_specializations), " total):")
+        # Group by module for better organization
+        module_specs = Dict{Module, Vector{String}}()
+        for ci in info.internal_method_specializations
+            if isa(ci, Core.CodeInstance) && isa(ci.def, Core.MethodInstance)
+                mi = ci.def
+                if isa(mi.def, Method)
+                    method = mi.def
+                    mod = method.module
+                    if !haskey(module_specs, mod)
+                        module_specs[mod] = String[]
+                    end
+                    # Use Julia's compact method signature display
+                    signature = sprint(Base.show_tuple_as_call, Symbol(""), mi.specTypes)
+                    # Truncate if rtruncate is available to avoid wrapping
+                    if isdefined(Base, :rtruncate)
+                        terminal_width = Base.displaysize(io)[2]
+                        indent_width = 8  # "      " prefix for each spec line
+                        max_width = max(40, terminal_width - indent_width)
+                        signature = Base.rtruncate(signature, max_width)
+                    end
+                    push!(module_specs[mod], signature)
+                end
+            end
+        end
+
+        sorted_modules = sort(collect(module_specs); by=x->length(x[2]), rev=true)
+        for (mod, specs) in sorted_modules
+            println(io, "    ", nameof(mod), " (", length(specs), " specializations):")
+            # Sort the specializations
+            sort!(specs)
+            for spec in specs
+                println(io, "      ", spec)
+            end
+        end
+    end
+end
 
 function Base.show(io::IO, info::PkgCacheInfo)
     nspecs = count_module_specializations(info.new_specializations)
@@ -152,37 +425,64 @@ function Base.show(io::IO, info::PkgCacheInfo)
     internal_methods = count_internal_methods(info)
     total_internal = sum(values(internal_methods))
 
-    # Try to count internal specializations if MethodAnalysis is available
-    internal_specs = Dict{Module,Int}()
-    total_internal_specs = 0
-    internal_specs_sorted = Pair{Module,Int}[]
+    # Count internal method specializations from the filtered list
+    internal_method_spec_counts = Dict{Module,Int}()
+    for ci in info.internal_method_specializations
+        if isa(ci, Core.CodeInstance) && isa(ci.def, Core.MethodInstance)
+            mi = ci.def
+            if isa(mi.def, Method)
+                method = mi.def
+                mod = method.module
+                internal_method_spec_counts[mod] = get(internal_method_spec_counts, mod, 0) + 1
+            end
+        end
+    end
+    internal_method_spec_sorted = sort(collect(internal_method_spec_counts); by=last, rev=true)
+    total_internal_method_specs = sum(last, internal_method_spec_sorted; init=0)
 
+    # Try to count internal specializations if MethodAnalysis is available (for compatibility)
     internal_specs = count_internal_specializations(info)
     if internal_specs !== nothing
         internal_specs_sorted = sort(collect(internal_specs); by=last, rev=true)
         total_internal_specs = sum(last, internal_specs_sorted; init=0)
+    else
+        # Use our filtered data as fallback
+        internal_specs_sorted = internal_method_spec_sorted
+        total_internal_specs = total_internal_method_specs
     end
 
     println(io, "Contents of ", info.cachefile, ':')
     println(io, "  modules: ", info.modules)
     !isempty(info.init_order) && println(io, "  init order: ", info.init_order)
 
-    # Show internal methods
+    # Internal methods: always print a one-line summary; in verbose mode add the detail block.
     if total_internal > 0
-        println(io, "  ", total_internal, " internal methods")
+        print(io, "  ", total_internal, " internal methods")
         if length(internal_methods) > 1
-            print(io, "    (")
+            print(io, " (")
             sorted_internal = sort(collect(internal_methods); by=last, rev=true)
             for i = 1:length(sorted_internal)
                 mod, count = sorted_internal[i]
                 print(io, i==1 ? "" : ", ", nameof(mod), " ", count)
             end
-            println(io, ")")
+            print(io, ")")
         end
+        println(io)
+    end
+    if info.verbose == :internal || info.verbose == :all
+        show_verbose_internal_methods(io, info)
     end
 
-    # Show internal specializations
-    if internal_specs === nothing
+    # Internal method specializations: summary line, plus detail in verbose mode.
+    if total_internal_method_specs > 0
+        print(io, "  ", total_internal_method_specs, " specializations of internal methods ")
+        for i = 1:min(3, length(internal_method_spec_sorted))
+            mod, count = internal_method_spec_sorted[i]
+            pct = round(100*count/total_internal_method_specs; digits=1)
+            print(io, i==1 ? "(" : ", ", nameof(mod), " ", pct, "%")
+        end
+        println(io, length(internal_method_spec_sorted) > 3 ? ", ...)" : ")")
+    elseif internal_specs === nothing
         println(io, "  specializations of internal methods: (requires MethodAnalysis.jl)")
     elseif total_internal_specs > 0
         print(io, "  ", total_internal_specs, " specializations of internal methods ")
@@ -193,7 +493,17 @@ function Base.show(io::IO, info::PkgCacheInfo)
         end
         println(io, length(internal_specs_sorted) > 3 ? ", ...)" : ")")
     end
+    if info.verbose == :internal || info.verbose == :all
+        show_verbose_internal_method_specializations(io, info)
+        if internal_specs !== nothing && total_internal_specs != total_internal_method_specs
+            println(io, "  MethodAnalysis internal specializations (", total_internal_specs, " total):")
+            for (mod, count) in internal_specs_sorted
+                println(io, "    ", nameof(mod), ": ", count, " specializations")
+            end
+        end
+    end
 
+    # External methods: summary lines, plus detail in verbose mode.
     !isempty(info.external_methods) && println(io, "  ", length(info.external_methods), " external methods")
     if !isempty(info.new_specializations)
         print(io, "  ", length(info.new_specializations), " new specializations of external methods ")
@@ -203,8 +513,12 @@ function Base.show(io::IO, info::PkgCacheInfo)
         end
         println(io, length(nspecs) > 3 ? ", ...)" : ")")
     end
+    if info.verbose == :external || info.verbose == :all
+        show_verbose_external_methods(io, info)
+    end
+
     !isempty(info.new_method_roots) && println(io, "  ", length(info.new_method_roots) ÷ 2, " external methods with new roots")
-    !isempty(info.edges) && println(io, "  ", length(info.edges) ÷ 2, " edges")
+
     println(io, "  ", rpad("file size: ", cache_displaynames_l+2), info.filesize, " (", Base.format_bytes(info.filesize),")")
     show(IOContext(io, :indent => 2), info.cachesizes)
     println(io, "  Image targets: ")
@@ -228,12 +542,15 @@ end
 # count_internal_specializations is defined in MethodAnalysisExt when MethodAnalysis is loaded
 count_internal_specializations(::Any) = nothing
 
+# `Core.GlobalMethods` was renamed to `Core.methodtable` in Julia 1.12 (#59158).
+const _GLOBAL_METHODS = isdefined(Core, :methodtable) ? Core.methodtable : getfield(Core, :GlobalMethods)
+
 # Count the number of methods defined within each of the package's own modules.
 # These are methods that belong to the modules stored in the package image,
 # as opposed to external methods which extend functions from other modules.
 function count_internal_methods(info::PkgCacheInfo)
     method_counts = Dict{Module,Int}()
-    Base.visit(Core.GlobalMethods) do method
+    Base.visit(_GLOBAL_METHODS) do method
         if method.module in info.modules
             method_counts[method.module] = get(method_counts, method.module, 0) + 1
         end
@@ -241,7 +558,7 @@ function count_internal_methods(info::PkgCacheInfo)
     return method_counts
 end
 
-function info_cachefile(pkg::PkgId, path::String, depmods::Vector{Any}, image_targets::Vector{Any}, isocache::Bool=false)
+function info_cachefile(pkg::PkgId, path::String, depmods::Vector{Any}, image_targets::Vector{Any}, isocache::Bool=false, verbose::Symbol=:none)
     if isocache
         sv = ccall(:jl_restore_package_image_from_file, Any, (Cstring, Any, Cint, Cstring, Cint), path, depmods, true, pkg.name, false)
     else
@@ -251,17 +568,36 @@ function info_cachefile(pkg::PkgId, path::String, depmods::Vector{Any}, image_ta
         throw(sv)
     end
     Base.register_restored_modules(sv, pkg, path)
-    return PkgCacheInfo(path, sv[1:6]..., filesize(path), PkgCacheSizes(sv[7]...), image_targets)
+
+    parts = _unpack_restored_sv(sv)
+    # External method extensions: pkg-defined methods that extend functions in other modules.
+    # On 1.12 these come from the dedicated `extext_methods` slot; on 1.13+ they are mixed
+    # into the unified `internal_methods` array as TypeMapEntries. Either way, unwrap to Method.
+    external_methods = Method[te.func for te in parts.extext_entries if isa(te.func, Method)]
+    # Split CodeInstances by whether their owning method belongs to the package's modules.
+    internal_method_specializations, new_specializations =
+        _split_code_instances(parts.code_instances, parts.modules)
+
+    info = PkgCacheInfo(path, parts.modules, parts.init_order,
+                        external_methods, internal_method_specializations,
+                        new_specializations, parts.method_roots_list,
+                        Any[], filesize(path),
+                        PkgCacheSizes(parts.cachesizes_raw...),
+                        image_targets, verbose)
+    return info
 end
 
-function info_cachefile(pkg::PkgId, path::String)
+function info_cachefile(pkg::PkgId, path::String, verbose::Symbol=:none)
     return @lock require_lock begin
         local depmodnames, image_targets
         io = open(path, "r")
         try
             # isvalid_cache_header returns checksum id or zero
             isvalid_cache_header(io) == 0 && return ArgumentError("Invalid header in cache file $path.")
-            depmodnames, clone_targets = parse_cache_header(io, path)[[3,7]]
+            header = parse_cache_header(io, path)
+            depmodnames = header[3]
+            # Position of `clone_targets` differs between Julia versions; locate it by type.
+            clone_targets = header[findfirst(x -> x isa Vector{UInt8}, header)::Int]
             image_targets = Any[Base.parse_image_targets(clone_targets)...]
             isvalid_file_crc(io) || return ArgumentError("Invalid checksum in cache file $path.")
         finally
@@ -279,30 +615,43 @@ function info_cachefile(pkg::PkgId, path::String)
         end
         # then load the file
         if isdefined(Base, :ocachefile_from_cachefile)
-            return info_cachefile(pkg, Base.ocachefile_from_cachefile(path), depmods, image_targets, true)
+            return info_cachefile(pkg, Base.ocachefile_from_cachefile(path), depmods, image_targets, true, verbose)
         end
-        info_cachefile(pkg, path, depmods, image_targets)
+        info_cachefile(pkg, path, depmods, image_targets, false, verbose)
     end
 end
 
-function info_cachefile(pkg::PkgId)
+function info_cachefile(pkg::PkgId, verbose::Symbol=:none)
     cachefiles = find_all_in_cache_path(pkg)
     isempty(cachefiles) && error(pkg, " has not yet been precompiled for julia ", Base.VERSION)
-    pkgpath = locate_package(pkg)
+    # On Julia >= 1.13 use `PkgLoadSpec` so the cache's recorded syntax version is checked
+    # against the manifest entry rather than the running `VERSION`.
+    pkgspec = if isdefined(Base, :locate_package_load_spec)
+        Base.locate_package_load_spec(pkg)
+    else
+        locate_package(pkg)
+    end
+    pkgspec === nothing && error("could not locate package ", pkg)
     idx = findfirst(cachefiles) do cf
-        stale_cachefile(pkgpath, cf) !== true
+        stale_cachefile(pkgspec, cf) !== true
     end
     idx === nothing && error("all cache files for ", pkg, " are stale, please precompile")
-    return info_cachefile(pkg, cachefiles[idx])
+    return info_cachefile(pkg, cachefiles[idx], verbose)
 end
 
 """
-    info_cachefile(pkgname::AbstractString) → cf
-    info_cachefile(pkgid::Base.PkgId) → cf
-    info_cachefile(pkgid::Base.PkgId, ji_cachefilename) → cf
+    info_cachefile(pkgname::AbstractString; verbose::Symbol=:none) → cf
+    info_cachefile(pkgid::Base.PkgId; verbose::Symbol=:none) → cf
+    info_cachefile(pkgid::Base.PkgId, ji_cachefilename; verbose::Symbol=:none) → cf
 
 Return a snapshot `cf` of a package cache file. Displaying `cf` prints a summary of the contents,
 but the fields of `cf` can be inspected to get further information (see [`PkgCacheInfo`](@ref)).
+
+The `verbose` parameter controls the level of detail in the output:
+- `:none` (default): Show summary information only
+- `:internal`: Show detailed information about internal methods
+- `:external`: Show detailed information about external methods and specializations
+- `:all`: Show detailed information about both internal and external methods
 
 After calling `info_cachefile("MyPkg")` you can also execute `using MyPkg` to make the image loaded by
 `info_cachefile` available for use. This can allow you to load `cf`s for multiple packages into the same session
@@ -313,6 +662,6 @@ for deeper analysis.
     already been loaded into your session. Restarting with a clean session and using `info_cachefile`
     before otherwise loading the package is recommended.
 """
-info_cachefile(pkgname::AbstractString) = info_cachefile(Base.identify_package(pkgname))
+info_cachefile(pkgname::AbstractString; verbose::Symbol=:none) = info_cachefile(Base.identify_package(pkgname), verbose)
 
 end

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -124,8 +124,13 @@ struct PkgCacheInfo
     """
     init_order::Vector{Any}
     """
-    The list of methods added to external modules. E.g., `Base.push!(v::MyNewVector, x)`.
-    These are methods that extend functions owned by other modules.
+    Every method defined by this pkgimage that must be re-installed into the global
+    method table at load time via `jl_method_table_activate` (the underlying
+    `TypeMapEntry`s live in `extext_entries`). On modern Julia with a single
+    global `jl_method_table`, this includes **all** worklist-defined methods, not only
+    methods extending externally-owned functions — the historic "extext" / "external"
+    name predates the single-global-mt design. Use [`extending_external_methods`](@ref)
+    to filter to the true "extending external" subset.
 
     !!! note
         On Julia 1.13 through Julia 1.14.0-DEV (prior to the upstream fix that restores
@@ -170,10 +175,13 @@ struct PkgCacheInfo
     """
     image_targets::Vector{Any}
     """
-    Methods defined by this package image as extracted directly from the `internal_methods`
-    array returned by the loader (Julia ≥ 1.13). Empty on Julia 1.12 where the loader does not
-    surface this list; in that case `count_internal_methods` falls back to walking the global
-    method table.
+    Methods reached by the loader's fixup walk on this pkgimage (Julia ≥ 1.13). These are
+    the `Method` objects whose `primary_world` field is bumped by `jl_activate_methods`;
+    on the current single-global-`jl_method_table` design they are the same `Method`s
+    that `external_methods` wraps in `TypeMapEntry`s, just enumerated as bare
+    `Method` objects for a different load-time purpose. Empty on Julia 1.12 where the
+    loader does not surface this list; in that case `count_internal_methods` falls back
+    to walking the global method table.
     """
     internal_methods::Vector{Method}
     """
@@ -352,14 +360,13 @@ end
 Display detailed information about external methods when verbose mode is enabled.
 """
 function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
-    # Show truly external methods (extension methods defined for functions in other modules)
-    if !isempty(info.external_methods)
-        print(io, "  "); _header(io, "External methods (extending functions from other modules)")
-        print(io, " ("); _count(io, length(info.external_methods)); println(io, " total):")
-        # Group unique method definitions by the module that owns the function being extended.
-        # `method.module` is the defining (worklist) module — uninformative for extension methods,
-        # which by definition all live in the worklist module. Use the function-owner module instead.
-        external_method_defs = Set{Method}(m for m in info.external_methods if isa(m, Method))
+    # Show truly external methods (methods extending functions owned by other modules).
+    ext_exts = extending_external_methods(info)
+    if !isempty(ext_exts)
+        print(io, "  "); _header(io, "Methods extending external functions")
+        print(io, " ("); _count(io, length(ext_exts)); println(io, " total):")
+        # Group by the module that owns the function being extended.
+        external_method_defs = Set{Method}(ext_exts)
 
         module_methods = Dict{Module, Vector{Method}}()
         for method in external_method_defs
@@ -528,9 +535,13 @@ function Base.show(io::IO, info::PkgCacheInfo)
         end
     end
 
-    # External methods: summary lines, plus detail in verbose mode.
-    if !isempty(info.external_methods)
-        print(io, "  "); _count(io, length(info.external_methods)); println(io, " external methods")
+    # External methods: show the truly-external subset (methods extending functions
+    # owned by modules outside this pkgimage). On post-#58131 Julia (single global
+    # jl_method_table) info.external_methods contains *all* worklist methods, so the
+    # raw count would duplicate the "internal methods" line above.
+    ext_exts = extending_external_methods(info)
+    if !isempty(ext_exts)
+        print(io, "  "); _count(io, length(ext_exts)); println(io, " methods extending external functions")
     end
     if !isempty(info.new_specializations)
         print(io, "  "); _count(io, length(info.new_specializations)); print(io, " new specializations of external methods ")
@@ -632,6 +643,35 @@ function _with_verbose(cached::PkgCacheInfo, verbose::Symbol)
 end
 
 _cache_key(path) = try realpath(path) catch; path end
+
+"""
+    extending_external_methods(info::PkgCacheInfo) -> Vector{Method}
+
+Return the subset of [`info.external_methods`](@ref PkgCacheInfo) whose specialized
+function is owned by a module **outside** this pkgimage's worklist — i.e., the true
+"extending external functions" subset (e.g., a package's `Base.show(::IO, ::MyType)`
+method). Filters by the module of the function-type, obtained from
+`Base.unwrap_unionall(m.sig).parameters[1].name.module`.
+
+Methods whose signature does not begin with a singleton function type (e.g. constructors
+for builtin types, callable struct instances) are conservatively classified as extending
+external when their containing type's name module is outside the worklist.
+"""
+function extending_external_methods(info::PkgCacheInfo)
+    worklist = Set{Module}(info.modules)
+    out = Method[]
+    for m in info.external_methods
+        st = Base.unwrap_unionall(m.sig)
+        isa(st, DataType) || continue
+        isempty(st.parameters) && continue
+        ft = st.parameters[1]
+        ft = isa(ft, UnionAll) ? Base.unwrap_unionall(ft) : ft
+        isa(ft, DataType) || continue
+        isdefined(ft, :name) || continue
+        ft.name.module in worklist || push!(out, m)
+    end
+    return out
+end
 
 function info_cachefile(pkg::PkgId, path::String, depmods::Vector{Any}, image_targets::Vector{Any}, isocache::Bool=false, verbose::Symbol=:none)
     cache_key = _cache_key(path)

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -25,23 +25,22 @@ function _truncate_for(io::IO, s::AbstractString, indent::Int)
     return Base.rtruncate(s, max_width)
 end
 
-using Base: PkgId, require_lock, assert_havelock, isvalid_cache_header, parse_cache_header, isvalid_file_crc,
+using Base: PkgId, require_lock, isvalid_cache_header, parse_cache_header, isvalid_file_crc,
             _tryrequire_from_serialized, find_all_in_cache_path, locate_package, stale_cachefile
-using Core: SimpleVector
 
 """
 $(TYPEDEF)
 
 Stores the sizes of different "sections" of the pkgimage. The main section is the package image itself.
-However, reconstructing a pkgimage for use requires auxillary data, like the addresses of internal
+However, reconstructing a pkgimage for use requires auxiliary data, like the addresses of internal
 pointers that need to be modified to account for the actual base address into which the
-pkgimage was loaded. Each form of auxillary data gets stored in distinct sections.
+pkgimage was loaded. Each form of auxiliary data gets stored in distinct sections.
 
 $(FIELDS)
 """
 struct PkgCacheSizes
     """
-    Size of the image. This is the portion of the file that gets returns by `info_cachefile`.
+    Size of the image. This is the portion of the file that gets returned by `info_cachefile`.
     """
     sysdata::Int
     """
@@ -390,22 +389,13 @@ function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
         # Group by module for better organization
         module_specs = Dict{Module, Vector{String}}()
         for spec in info.new_specializations
-            if isa(spec, Core.CodeInstance) && isa(spec.def, Core.MethodInstance)
-                mi = spec.def
-                if isa(mi.def, Method)
-                    method = mi.def
-                    mod = method.module
-                    # Only include truly external methods here
-                    if mod ∉ info.modules
-                        if !haskey(module_specs, mod)
-                            module_specs[mod] = String[]
-                        end
-                        # Use Julia's compact method signature display (color-aware via io ctx).
-                        signature = sprint(Base.show_tuple_as_call, Symbol(""), mi.specTypes; context=io)
-                        push!(module_specs[mod], _truncate_for(io, signature, 8))
-                    end
-                end
-            end
+            mi = spec.def
+            isa(mi, Core.MethodInstance) && isa(mi.def, Method) || continue
+            mod = mi.def.module
+            specs = get!(() -> String[], module_specs, mod)
+            # Use Julia's compact method signature display (color-aware via io ctx).
+            signature = sprint(Base.show_tuple_as_call, Symbol(""), mi.specTypes; context=io)
+            push!(specs, _truncate_for(io, signature, 8))
         end
 
         sorted_modules = sort(collect(module_specs); by=x->length(x[2]), rev=true)
@@ -430,19 +420,13 @@ function show_verbose_internal_method_specializations(io::IO, info::PkgCacheInfo
         # Group by module for better organization
         module_specs = Dict{Module, Vector{String}}()
         for ci in info.internal_method_specializations
-            if isa(ci, Core.CodeInstance) && isa(ci.def, Core.MethodInstance)
-                mi = ci.def
-                if isa(mi.def, Method)
-                    method = mi.def
-                    mod = method.module
-                    if !haskey(module_specs, mod)
-                        module_specs[mod] = String[]
-                    end
-                    # Use Julia's compact method signature display (color-aware via io ctx).
-                    signature = sprint(Base.show_tuple_as_call, Symbol(""), mi.specTypes; context=io)
-                    push!(module_specs[mod], _truncate_for(io, signature, 8))
-                end
-            end
+            mi = ci.def
+            isa(mi, Core.MethodInstance) && isa(mi.def, Method) || continue
+            mod = mi.def.module
+            specs = get!(() -> String[], module_specs, mod)
+            # Use Julia's compact method signature display (color-aware via io ctx).
+            signature = sprint(Base.show_tuple_as_call, Symbol(""), mi.specTypes; context=io)
+            push!(specs, _truncate_for(io, signature, 8))
         end
 
         sorted_modules = sort(collect(module_specs); by=x->length(x[2]), rev=true)
@@ -468,14 +452,10 @@ function Base.show(io::IO, info::PkgCacheInfo)
     # Count internal method specializations from the filtered list
     internal_method_spec_counts = Dict{Module,Int}()
     for ci in info.internal_method_specializations
-        if isa(ci, Core.CodeInstance) && isa(ci.def, Core.MethodInstance)
-            mi = ci.def
-            if isa(mi.def, Method)
-                method = mi.def
-                mod = method.module
-                internal_method_spec_counts[mod] = get(internal_method_spec_counts, mod, 0) + 1
-            end
-        end
+        mi = ci.def
+        isa(mi, Core.MethodInstance) && isa(mi.def, Method) || continue
+        mod = mi.def.module
+        internal_method_spec_counts[mod] = get(internal_method_spec_counts, mod, 0) + 1
     end
     internal_method_spec_sorted = sort(collect(internal_method_spec_counts); by=last, rev=true)
     total_internal_method_specs = sum(last, internal_method_spec_sorted; init=0)
@@ -643,17 +623,24 @@ function count_internal_methods(info::PkgCacheInfo)
     return method_counts
 end
 
+# Build a fresh `PkgCacheInfo` from a cached one, swapping in a new `verbose` mode.
+function _with_verbose(cached::PkgCacheInfo, verbose::Symbol)
+    cached.verbose === verbose && return cached
+    return PkgCacheInfo(cached.cachefile, cached.modules, cached.init_order,
+                        cached.external_methods, cached.internal_method_specializations,
+                        cached.new_specializations, cached.new_method_roots,
+                        cached.edges, cached.filesize, cached.cachesizes,
+                        cached.image_targets, cached.internal_methods, verbose)
+end
+
+_cache_key(path) = try realpath(path) catch; path end
+
 function info_cachefile(pkg::PkgId, path::String, depmods::Vector{Any}, image_targets::Vector{Any}, isocache::Bool=false, verbose::Symbol=:none)
-    cache_key = try realpath(path) catch; path end
+    cache_key = _cache_key(path)
     cached = get(_INFO_CACHE, cache_key, nothing)
     if cached !== nothing
         @warn "`info_cachefile` already called for this cache file; returning cached result. Reloading the same pkgimage in one session would corrupt the runtime." path
-        return cached.verbose === verbose ? cached :
-            PkgCacheInfo(cached.cachefile, cached.modules, cached.init_order,
-                         cached.external_methods, cached.internal_method_specializations,
-                         cached.new_specializations, cached.new_method_roots,
-                         cached.edges, cached.filesize, cached.cachesizes,
-                         cached.image_targets, cached.internal_methods, verbose)
+        return _with_verbose(cached, verbose)
     end
     if isocache
         sv = ccall(:jl_restore_package_image_from_file, Any, (Cstring, Any, Cint, Cstring, Cint), path, depmods, true, pkg.name, false)
@@ -700,6 +687,22 @@ function info_cachefile(pkg::PkgId, path::String; verbose::Symbol=:none)
         finally
             close(io)
         end
+        # Determine the actual file `jl_restore_*` will load. Only use the ocache (native-code)
+        # path when the cache actually has clone targets recorded; otherwise the `.so`/`.dylib`
+        # may not exist (notably on Julia 1.11 when precompilation was done without native code).
+        load_path, isocache = if !isempty(image_targets) && isdefined(Base, :ocachefile_from_cachefile)
+            Base.ocachefile_from_cachefile(path), true
+        else
+            path, false
+        end
+        # Fast path: same cache file already inspected this session. Avoids reloading deps and
+        # the segfault-prone second `jl_restore_*` call. Keyed by the resolved load path so all
+        # entry-point variants (.ji vs .so) hit the same entry.
+        cached = get(_INFO_CACHE, _cache_key(load_path), nothing)
+        if cached !== nothing
+            @warn "`info_cachefile` already called for this cache file; returning cached result. Reloading the same pkgimage in one session would corrupt the runtime." path
+            return _with_verbose(cached, verbose)
+        end
         ndeps = length(depmodnames)
         depmods = Vector{Any}(undef, ndeps)
         for i in 1:ndeps
@@ -710,13 +713,7 @@ function info_cachefile(pkg::PkgId, path::String; verbose::Symbol=:none)
             end
             depmods[i] = dep
         end
-        # then load the file. Only use the ocache (native-code) path when the cache actually
-        # has clone targets recorded; otherwise the `.so`/`.dylib` may not exist (notably on
-        # Julia 1.11 when precompilation was performed without native code generation).
-        if !isempty(image_targets) && isdefined(Base, :ocachefile_from_cachefile)
-            return info_cachefile(pkg, Base.ocachefile_from_cachefile(path), depmods, image_targets, true, verbose)
-        end
-        info_cachefile(pkg, path, depmods, image_targets, false, verbose)
+        info_cachefile(pkg, load_path, depmods, image_targets, isocache, verbose)
     end
 end
 

--- a/src/PkgCacheInspector.jl
+++ b/src/PkgCacheInspector.jl
@@ -110,6 +110,13 @@ struct PkgCacheInfo
     """
     The list of methods added to external modules. E.g., `Base.push!(v::MyNewVector, x)`.
     These are methods that extend functions owned by other modules.
+
+    !!! note
+        On Julia 1.13 through Julia 1.14.0-DEV (prior to the upstream fix that restores
+        `extext_methods` to the inspector svec), this list is always empty: the underlying
+        `TypeMapEntry` array is populated by the loader but discarded before it reaches
+        external callers. The information is therefore unavailable to PkgCacheInspector on
+        those releases.
     """
     external_methods::Vector{Any}
     """
@@ -124,8 +131,9 @@ struct PkgCacheInfo
     """
     new_specializations::Vector{Any}
     """
-    New GC roots added to external methods. These are an important but internal detail of how type-inferred code
-    is compressed for serialization.
+    Methods that gained new GC roots during precompilation, paired flat as
+    `[method, roots, method, roots, …]`. This includes both internal and external methods.
+    These roots are an internal detail of how type-inferred code is compressed for serialization.
     """
     new_method_roots::Vector{Any}
     """
@@ -146,11 +154,18 @@ struct PkgCacheInfo
     """
     image_targets::Vector{Any}
     """
+    Methods defined by this package image as extracted directly from the `internal_methods`
+    array returned by the loader (Julia ≥ 1.13). Empty on Julia 1.12 where the loader does not
+    surface this list; in that case `count_internal_methods` falls back to walking the global
+    method table.
+    """
+    internal_methods::Vector{Any}
+    """
     Verbose output mode for displaying method information.
     """
     verbose::Symbol
 end
-PkgCacheInfo(cachefile::AbstractString, modules) = PkgCacheInfo(cachefile, modules, [], [], [], [], [], [], 0, PkgCacheSizes(), [], :none)
+PkgCacheInfo(cachefile::AbstractString, modules) = PkgCacheInfo(cachefile, modules, [], [], [], [], [], [], 0, PkgCacheSizes(), [], [], :none)
 
 """
     _unpack_restored_sv(sv) -> NamedTuple
@@ -158,13 +173,21 @@ PkgCacheInfo(cachefile::AbstractString, modules) = PkgCacheInfo(cachefile, modul
 Unpack the SimpleVector returned by `jl_restore_incremental`/`jl_restore_package_image_from_file`
 (with `completeinfo=true`), normalizing across Julia versions.
 
-Julia 1.12 returns a 7-element svec: `(restored, init_order, edges, ext_edges, extext_methods,
-method_roots_list, cachesizes_sv)`.
+Four layouts are supported:
 
-Julia 1.13+ (and master) returns a 5-element svec: `(restored, init_order, internal_methods,
-method_roots_list, cachesizes_sv)` where `internal_methods` is a flat heterogeneous list mixing
-`Core.TypeMapEntry` (the old `extext_methods`), `Method` (new internal methods), and
-`Core.CodeInstance` (the old `edges` and `ext_edges` merged).
+- Julia 1.11 (8-elem): `(restored, init_order, extext_methods, new_ext_cis,
+  method_roots_list, ext_targets, edges, cachesizes_sv)`. `ext_targets` is unused here.
+- Julia 1.12 (7-elem): `(restored, init_order, edges, ext_edges, extext_methods,
+  method_roots_list, cachesizes_sv)`.
+- Julia 1.13 .. 1.14.0-DEV pre-fix (5-elem): `(restored, init_order, internal_methods,
+  method_roots_list, cachesizes_sv)` where `internal_methods` mixes `Method` and `CodeInstance`.
+  On these releases the `extext_methods` (TypeMapEntries) and `new_ext_cis` arrays are
+  populated inside the loader but **dropped** before being returned, so `extext_entries` is
+  always empty here. See the JuliaLang/julia source `staticdata.c` for the fix.
+- Post-fix master (7-elem): `(restored, init_order, internal_methods, extext_methods,
+  new_ext_cis, method_roots_list, cachesizes_sv)`. Distinguished from the 1.12 7-elem
+  layout by `VERSION` (the layouts are not type-distinguishable when their arrays are
+  empty).
 """
 function _unpack_restored_sv(sv)
     n = length(sv)
@@ -172,23 +195,44 @@ function _unpack_restored_sv(sv)
     init_order = sv[2]
     code_instances = Core.CodeInstance[]
     extext_entries = Core.TypeMapEntry[]
-    if n == 7
-        # Julia 1.12 layout
+    internal_methods = Method[]
+    if n == 8
+        # Julia 1.11 layout: extext_methods, new_ext_cis, method_roots, ext_targets, edges, cachesizes
+        for x in sv[3]; isa(x, Core.TypeMapEntry) && push!(extext_entries, x); end
+        for x in sv[4]; isa(x, Core.CodeInstance) && push!(code_instances, x); end
+        for x in sv[7]; isa(x, Core.CodeInstance) && push!(code_instances, x); end
+        method_roots_list = sv[5]
+        cachesizes_raw = sv[8]
+    elseif n == 7 && VERSION < v"1.13-"
+        # Julia 1.12 layout: edges, ext_edges, extext_methods
         for x in sv[3]; isa(x, Core.CodeInstance) && push!(code_instances, x); end
         for x in sv[4]; isa(x, Core.CodeInstance) && push!(code_instances, x); end
         for x in sv[5]; isa(x, Core.TypeMapEntry) && push!(extext_entries, x); end
         method_roots_list = sv[6]
         cachesizes_raw = sv[7]
-    elseif n == 5
-        # Julia 1.13+/master layout
+    elseif n == 7
+        # Post-fix master layout: internal_methods, extext_methods, new_ext_cis
         for x in sv[3]
             if isa(x, Core.CodeInstance)
                 push!(code_instances, x)
+            elseif isa(x, Method)
+                push!(internal_methods, x)
+            end
+        end
+        for x in sv[4]; isa(x, Core.TypeMapEntry) && push!(extext_entries, x); end
+        for x in sv[5]; isa(x, Core.CodeInstance) && push!(code_instances, x); end
+        method_roots_list = sv[6]
+        cachesizes_raw = sv[7]
+    elseif n == 5
+        # Julia 1.13 .. 1.14.0-DEV pre-fix layout (buggy: extext_entries is unavailable).
+        for x in sv[3]
+            if isa(x, Core.CodeInstance)
+                push!(code_instances, x)
+            elseif isa(x, Method)
+                push!(internal_methods, x)
             elseif isa(x, Core.TypeMapEntry)
                 push!(extext_entries, x)
             end
-            # Methods present in this list are also discoverable via `Core.methodtable`,
-            # so they are accounted for by `count_internal_methods`.
         end
         method_roots_list = sv[4]
         cachesizes_raw = sv[5]
@@ -196,7 +240,7 @@ function _unpack_restored_sv(sv)
         error("Unexpected SimpleVector layout (length $n) returned by Julia $(VERSION); ",
               "PkgCacheInspector needs updating.")
     end
-    return (; modules, init_order, code_instances, extext_entries,
+    return (; modules, init_order, code_instances, extext_entries, internal_methods,
               method_roots_list, cachesizes_raw)
 end
 
@@ -298,12 +342,14 @@ function show_verbose_external_methods(io::IO, info::PkgCacheInfo)
     # Show truly external methods (extension methods defined for functions in other modules)
     if !isempty(info.external_methods)
         println(io, "  External methods (extending functions from other modules) (", length(info.external_methods), " total):")
-        # Group unique method definitions by the module that owns the function being extended
+        # Group unique method definitions by the module that owns the function being extended.
+        # `method.module` is the defining (worklist) module — uninformative for extension methods,
+        # which by definition all live in the worklist module. Use the function-owner module instead.
         external_method_defs = Set{Method}(m for m in info.external_methods if isa(m, Method))
 
         module_methods = Dict{Module, Vector{Method}}()
         for method in external_method_defs
-            mod = method.module
+            mod = _extension_owner_module(method)
             if !haskey(module_methods, mod)
                 module_methods[mod] = Method[]
             end
@@ -517,7 +563,7 @@ function Base.show(io::IO, info::PkgCacheInfo)
         show_verbose_external_methods(io, info)
     end
 
-    !isempty(info.new_method_roots) && println(io, "  ", length(info.new_method_roots) ÷ 2, " external methods with new roots")
+    !isempty(info.new_method_roots) && println(io, "  ", length(info.new_method_roots) ÷ 2, " methods with new roots")
 
     println(io, "  ", rpad("file size: ", cache_displaynames_l+2), info.filesize, " (", Base.format_bytes(info.filesize),")")
     show(IOContext(io, :indent => 2), info.cachesizes)
@@ -542,14 +588,45 @@ end
 # count_internal_specializations is defined in MethodAnalysisExt when MethodAnalysis is loaded
 count_internal_specializations(::Any) = nothing
 
+# For a method extending an externally-owned function, recover the module that owns the
+# function. The first signature parameter is `Type{typeof(f)}` for normal calls, or the
+# functor's own type for callable-object methods.
+function _extension_owner_module(method::Method)
+    sig = Base.unwrap_unionall(method.sig)
+    isa(sig, DataType) || return method.module
+    isempty(sig.parameters) && return method.module
+    t1 = sig.parameters[1]
+    if isa(t1, DataType) && t1.name === Type.body.name && !isempty(t1.parameters)
+        ft = t1.parameters[1]
+        isa(ft, DataType) && return ft.name.module
+    elseif isa(t1, DataType)
+        return t1.name.module
+    end
+    return method.module
+end
+
 # `Core.GlobalMethods` was renamed to `Core.methodtable` in Julia 1.12 (#59158).
-const _GLOBAL_METHODS = isdefined(Core, :methodtable) ? Core.methodtable : getfield(Core, :GlobalMethods)
+# On Julia 1.11 neither exists publicly; the global walk fallback is simply unavailable
+# there (count_internal_methods will rely on info.internal_methods when populated).
+const _GLOBAL_METHODS = isdefined(Core, :methodtable) ? Core.methodtable :
+                       isdefined(Core, :GlobalMethods) ? getfield(Core, :GlobalMethods) :
+                       nothing
 
 # Count the number of methods defined within each of the package's own modules.
-# These are methods that belong to the modules stored in the package image,
-# as opposed to external methods which extend functions from other modules.
+# On Julia >= 1.13 the loader hands us the exact `Method` list for this pkgimage in
+# `info.internal_methods`; use it for an accurate per-package count. On Julia 1.12 (and as a
+# safety fallback) walk the global method table and filter by module — note this over-counts
+# in long sessions because it includes methods registered before `info_cachefile` was called.
 function count_internal_methods(info::PkgCacheInfo)
     method_counts = Dict{Module,Int}()
+    if !isempty(info.internal_methods)
+        for m in info.internal_methods
+            isa(m, Method) || continue
+            method_counts[m.module] = get(method_counts, m.module, 0) + 1
+        end
+        return method_counts
+    end
+    _GLOBAL_METHODS === nothing && return method_counts
     Base.visit(_GLOBAL_METHODS) do method
         if method.module in info.modules
             method_counts[method.module] = get(method_counts, method.module, 0) + 1
@@ -583,7 +660,7 @@ function info_cachefile(pkg::PkgId, path::String, depmods::Vector{Any}, image_ta
                         new_specializations, parts.method_roots_list,
                         Any[], filesize(path),
                         PkgCacheSizes(parts.cachesizes_raw...),
-                        image_targets, verbose)
+                        image_targets, parts.internal_methods, verbose)
     return info
 end
 
@@ -613,8 +690,10 @@ function info_cachefile(pkg::PkgId, path::String, verbose::Symbol=:none)
             end
             depmods[i] = dep
         end
-        # then load the file
-        if isdefined(Base, :ocachefile_from_cachefile)
+        # then load the file. Only use the ocache (native-code) path when the cache actually
+        # has clone targets recorded; otherwise the `.so`/`.dylib` may not exist (notably on
+        # Julia 1.11 when precompilation was performed without native code generation).
+        if !isempty(image_targets) && isdefined(Base, :ocachefile_from_cachefile)
             return info_cachefile(pkg, Base.ocachefile_from_cachefile(path), depmods, image_targets, true, verbose)
         end
         info_cachefile(pkg, path, depmods, image_targets, false, verbose)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,9 @@
+[deps]
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+MethodAnalysis = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+PkgCacheInspector = "a408fb95-4068-4cfa-a7f1-12fd503bd86c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+PkgCacheInspector = {path = ".."}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ Pkg.precompile()
 module EmptyPkg end
 
 @testset "PkgCacheInspector.jl" begin
-    info = info_cachefile("Colors")
+    info = info_cachefile("Colors", verbose = :all)
     @test isa(info, PkgCacheInfo)
     str = sprint(show, info)
     @test occursin("relocations", str) && occursin("new specializations", str) && occursin("targets", str)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using PkgCacheInspector
+using PkgCacheInspector: extending_external_methods
 using MethodAnalysis
 using Test
 using Pkg
@@ -42,4 +43,15 @@ end
     str = sprint(show, info)
     @test occursin(r"modules: .*EmptyPkg\]", str)
     @test occursin(r"file size: +0 \(0 bytes\)", str)
+
+    # extending_external_methods returns a subset of external_methods, filtered to those
+    # whose function-type module is outside the worklist.
+    colors_info = info_cachefile("Colors", verbose = :none)
+    eem = extending_external_methods(colors_info)
+    @test eem isa Vector{Method}
+    @test issubset(Set(eem), Set(colors_info.external_methods))
+    worklist = Set(colors_info.modules)
+    @test all(m -> !(Base.unwrap_unionall(m.sig).parameters[1] isa DataType &&
+                     Base.unwrap_unionall(m.sig).parameters[1].name.module in worklist), eem)
+    @test isempty(extending_external_methods(empty_info("EmptyPkg.so", [EmptyPkg])))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,13 @@ module EmptyPkg end
     @test eltype(mis) === Core.MethodInstance
     @test length(mis) > 100
 
+    # Repeated info_cachefile on the same package returns the cached result with a warning
+    # (loading the same pkgimage twice in one session segfaults the runtime).
+    info_again = @test_logs (:warn, r"already called"i) info_cachefile("Colors", verbose = :none)
+    @test isa(info_again, PkgCacheInfo)
+    @test info_again.cachefile == info.cachefile
+    @test info_again.verbose === :none
+
     # Empty pkgimages do not cause issues
     info = PkgCacheInfo("EmptyPkg.so", [EmptyPkg])
     str = sprint(show, info)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,9 +5,17 @@ using Pkg
 
 @show Base.JLOptions().code_coverage   # coverage must be off to write .so pkgimages
 
-Pkg.precompile()
+Pkg.precompile("Colors")
 
 module EmptyPkg end
+
+# Test-only constructors for an "empty" PkgCacheInfo (no associated cachefile).
+empty_cachesizes() = PkgCacheSizes(0, 0, 0, 0, 0, 0, 0)
+function empty_info(cachefile::AbstractString, modules)
+    PkgCacheInfo(cachefile, Vector{Module}(modules), [], Method[],
+                 Core.CodeInstance[], Core.CodeInstance[], [], [],
+                 0, empty_cachesizes(), [], Method[], :none)
+end
 
 @testset "PkgCacheInspector.jl" begin
     info = info_cachefile("Colors", verbose = :all)
@@ -30,7 +38,7 @@ module EmptyPkg end
     @test info_again.verbose === :none
 
     # Empty pkgimages do not cause issues
-    info = PkgCacheInfo("EmptyPkg.so", [EmptyPkg])
+    info = empty_info("EmptyPkg.so", [EmptyPkg])
     str = sprint(show, info)
     @test occursin(r"modules: .*EmptyPkg\]", str)
     @test occursin(r"file size: +0 \(0 bytes\)", str)


### PR DESCRIPTION
This became a bit of a Claude take the wheel and fix everything...

Closes #41 

----

## Add verbose modes (and broader Julia compatibility)

Adds opt-in verbose output to `info_cachefile` for inspecting pkgimage
contents in detail, refreshes compatibility with current Julia versions
(1.11–nightly), and cleans up the surrounding code.

> Written with the assistance of generative AI (GitHub Copilot, Claude
> Opus 4.7).

### New `verbose` keyword on `info_cachefile`

`info_cachefile(pkg; verbose=:none)` now controls how much detail is
printed when a `PkgCacheInfo` is shown:

| value        | output                                                       |
|--------------|--------------------------------------------------------------|
| `:none`      | summary counts only (current default; unchanged behavior)    |
| `:internal`  | also list internal methods grouped by function, with their specializations |
| `:external`  | also list methods this package adds to functions defined elsewhere, plus any new external specializations |
| `:all`       | union of `:internal` and `:external`                         |

Method, specialization, and external-method lists are sorted for stable
output. External entries are filtered to those whose defining module is
not part of the package being inspected, so the section actually shows
*extension* of upstream functions rather than re-listing the package's
own methods.

Internal-method counting is reworked to walk `Core.methodtable` (renamed
from `Core.GlobalMethods` in 1.12) with a fallback to
`info.internal_methods` for older versions where the API isn't public.

Verbose rendering is colorized: headers, counts, module names, and the
function-name groupings are printed via `printstyled` so the output
highlights structure in color-capable terminals while remaining a no-op
under `sprint` and other colorless `IO`s. `Method` objects are rendered
through their own color-aware `show` (preserving source-location
highlighting), and the caller's `IOContext` is propagated through
`Base.show_tuple_as_call` so specialization signatures pick up color
too.

### Julia 1.11 / 1.12 / 1.13 / nightly compatibility

The cache-file plumbing has shifted shape across recent Julia versions;
this PR teaches the inspector to handle each:

- **1.11** (8-element restored sv: `(modules, init_order,
  extext_methods, new_ext_cis, method_roots_list, ext_targets, edges,
  cachesizes)`), **1.12/1.13**, and **master** layouts are all unpacked
  by a single `_unpack_restored_sv` helper.
- `parse_cache_header`'s return tuple grew a `syntax_version` element on
  master and replaced `prefs`/`prefs_hash` with `prefs_blob`, shifting
  `clone_targets` from index 7 to index 6. The PR locates
  `clone_targets` by type (`Vector{UInt8}`) so the code works on 1.12,
  1.13, and nightly without version branching.
- `Core.GlobalMethods` / `Core.methodtable` access is guarded so 1.11
  (which exposes neither publicly) falls through to
  `info.internal_methods` instead of erroring at top level.
- `ocachefile_from_cachefile` is only consulted when `clone_targets` is
  non-empty, matching upstream behavior when no pkgimage `.dylib` is
  associated with a `.ji`.
- Package lookup in `info_cachefile(pkg::PkgId, …)` uses
  `Base.locate_package_load_spec` when available so the cache's
  recorded syntax version is honored. This fixes spurious *"all cache
  files are stale"* errors on Julia 1.13+ when the active manifest was
  resolved with a different Julia version than the running one.

CI matrix expanded to `'1.11'`, `'1.12'`, `'1.13-nightly'`, `'nightly'`.
`Project.toml` is now a workspace with `test/` and `docs/` members
(adds `test/Project.toml`), and the `julia` compat is lowered to
`"1.11"`.

### Repeat-call safety

Loading the same pkgimage twice in one session via
`jl_restore_package_image_from_file` / `jl_restore_incremental`
corrupts the runtime and segfaults. `info_cachefile` now caches results
in a module-local `_INFO_CACHE` keyed by the realpath of the cache
file; on a repeat call it emits a warning and returns the prior
`PkgCacheInfo` (re-wrapped with the freshly requested `verbose`
setting) instead of re-invoking the loader. The fast-path runs before
any cache-file open, CRC check, or `_tryrequire_from_serialized` call.

### Code-quality cleanup

Folded into the same PR while the file was open:

- **Tighter types.** `PkgCacheInfo` fields move from `Vector{Any}` to
  concrete element types (`Vector{Method}` for `external_methods` and
  `internal_methods`, `Vector{Core.CodeInstance}` for
  `internal_method_specializations` and `new_specializations`). The
  fields were already populated with those concrete types; the loose
  typing only cost inference quality.
- **Kwarg consistency.** Every public `info_cachefile` entry point now
  accepts `verbose` as a keyword argument, matching the docstring.
- **Defensive helpers.** `count_module_specializations` and the verbose
  renderers gracefully skip non-`Method`-backed `CodeInstance`s.
- **Real errors.** `return ArgumentError(...)` on the invalid-header /
  bad-CRC paths is now `throw(ArgumentError(...))` so callers actually
  see a failure.
- **Dedupe by `Method`, not binding name.** `show_verbose_internal_methods`
  used to iterate `names(mod; all=true)` and call `methods(obj)` per
  binding, so gensym aliases (e.g. `var"#15#val"` aliasing
  `normalize_hue`) duplicated whole sections. It now collects into a
  `Method`-keyed set first and groups under the true function-owner
  symbol, so each `Method` is listed exactly once.
- **Dead-code / docs / typos.** Drops the unused `assert_havelock`
  import, the stub `moduleof(::Module)` method, redundant
  `isa(_, Core.CodeInstance)` chains, and a double blank line. Fixes
  `auxillary` → `auxiliary` and `!!! warn` → `!!! warning` so the
  Documenter admonition renders. Sets `checkdocs=:exports` so internal
  helpers don't break the docs build.
- **Renames.** Internal helpers `_n` / `_mod` / `_hdr` → `_count` /
  `_modname` / `_header` for self-documenting call sites. The test-only
  zero-arg `PkgCacheSizes()` and two-arg
  `PkgCacheInfo(cachefile, modules)` constructors moved out of the
  source module into `test/runtests.jl` as `empty_cachesizes()` /
  `empty_info(...)`. `Pkg.precompile()` in the test runner is scoped
  to `"Colors"` (the only inspected package).
- **`.gitignore`.** Excludes per-version root Manifests and
  `test/Manifest.toml`.

### Test plan

`Pkg.test()` passes on Julia **1.11**, **1.12**, **1.13.0-rc1**, and
**1.14.0-DEV** (9/9 tests on every version). Verbose rendering was
spot-checked against the Pkg, REPL, Dates, and Colors pkgimages on
1.14.0-DEV.

### Commits

1. `Add verbose modes and Julia 1.12/1.13/nightly compatibility`
2. `Support Julia 1.11`
3. `show_verbose_internal_methods: dedupe by Method, not binding name`
4. `show: colorize output and use color-aware Method rendering`
5. `info_cachefile: cache result to avoid double-load segfault`
6. `cleanup: tighten types, kwarg-ify verbose, defensive helpers`
7. `cleanup: prune dead code, tighten cache fast-path, fix typos`
8. `cleanup: rename color helpers, move test-only ctors, scope precompile`